### PR TITLE
Feat: improve visibility of topology graph and fix topology index

### DIFF
--- a/src/device/_components/TopologyInfo.tsx
+++ b/src/device/_components/TopologyInfo.tsx
@@ -79,7 +79,7 @@ const createNodeData = (
       tempNodeMap.set(qubit.id.toString(), qubit);
       return {
         id: qubit.id.toString(),
-        label: `Q${qubit.physical_id}`,
+        label: `Q${qubit.id}`,
         fx: scalePosition(qubit.position.x),
         fy: scalePosition(qubit.position.y * -1), // multiply by -1 to flip the y-axis
       };
@@ -130,6 +130,8 @@ export const TopologyInfo: React.FC<{ deviceInfo: string | undefined }> = ({ dev
   const [couplingMap, setCouplingMap] = useState<Map<string, object>>(new Map<string, object>());
   const [hoveredInfo, setStrHoveredInfo] = useState<object>({});
   const [isValidDeviceInfo, setIsValidDeviceInfo] = useState<boolean>(true);
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  const [hoveredLinkId, setHoveredLinkId] = useState<string | null>(null);
 
   useEffect(() => {
     try {
@@ -166,8 +168,12 @@ export const TopologyInfo: React.FC<{ deviceInfo: string | undefined }> = ({ dev
   const handleHoverNode = (node: NodeObject | null): void => {
     try {
       if (node !== null) {
-        const nodeInfo = nodeMap.get(node.id as string);
-        if (nodeInfo !== undefined) {
+        const nodeId = node.id as string;
+        const nodeInfo = nodeMap.get(nodeId);
+
+        if (nodeId !== undefined && nodeInfo !== undefined) {
+          setHoveredLinkId(null);
+          setHoveredNodeId(nodeId);
           setStrHoveredInfo(nodeInfo);
         }
       }
@@ -179,10 +185,14 @@ export const TopologyInfo: React.FC<{ deviceInfo: string | undefined }> = ({ dev
   const handleHoverLink = (link: LinkObject | null): void => {
     try {
       if (link !== null) {
-        const source = (link.source as NodeObject).id;
-        const target = (link.target as NodeObject).id;
-        const coupling = couplingMap.get(createCouplingMapKey(source as number, target as number));
-        if (coupling !== undefined) {
+        const sourceId = (link.source as NodeObject).id;
+        const targetId = (link.target as NodeObject).id;
+        const couplingKey = createCouplingMapKey(sourceId as number, targetId as number);
+        const coupling = couplingMap.get(couplingKey);
+
+        if (couplingKey !== undefined && coupling !== undefined) {
+          setHoveredNodeId(null);
+          setHoveredLinkId(couplingKey);
           setStrHoveredInfo(coupling);
         }
       }
@@ -284,8 +294,8 @@ export const TopologyInfo: React.FC<{ deviceInfo: string | undefined }> = ({ dev
               }
               ctx.fillStyle = '#4887fa';
               ctx.fill();
-              ctx.strokeStyle = 'white';
-              ctx.lineWidth = 1;
+              ctx.strokeStyle = node.id === hoveredNodeId ? '#fc6464' : 'white';
+              ctx.lineWidth = 3 / globalScale;
               ctx.stroke();
 
               const label =
@@ -299,10 +309,48 @@ export const TopologyInfo: React.FC<{ deviceInfo: string | undefined }> = ({ dev
                 ctx.fillText(label, node.x, node.y);
               }
             }}
-            linkWidth={8}
-            linkColor={() => '#4887fa'}
-            linkDirectionalArrowLength={0}
-            linkDirectionalArrowRelPos={0}
+            linkCanvasObject={(
+              link: LinkObject,
+              ctx: CanvasRenderingContext2D,
+              globalScale: number
+            ) => {
+              const { source, target } = link;
+              const startX = (source as NodeObject).x;
+              const startY = (source as NodeObject).y;
+              const endX = (target as NodeObject).x;
+              const endY = (target as NodeObject).y;
+              const sourceId = (link.source as NodeObject).id;
+              const targetId = (link.target as NodeObject).id;
+              const couplingKey = createCouplingMapKey(sourceId as number, targetId as number);
+
+              if (
+                startX !== undefined &&
+                startY !== undefined &&
+                endX !== undefined &&
+                endY !== undefined
+              ) {
+                // Drawing the outer line
+                const outerStrokeColor = couplingKey === hoveredLinkId ? '#fc6464' : 'transparent';
+
+                ctx.beginPath();
+                ctx.moveTo(startX, startY);
+                ctx.lineTo(endX, endY);
+                ctx.strokeStyle = outerStrokeColor;
+                ctx.lineWidth = 16 / globalScale;
+                ctx.stroke();
+
+                // Drawing the inner line
+                const innerStrokeColor = '#4887fa';
+
+                ctx.beginPath();
+                ctx.moveTo(startX, startY);
+                ctx.lineTo(endX, endY);
+                ctx.strokeStyle = innerStrokeColor;
+                ctx.lineWidth = 10 / globalScale;
+                ctx.stroke();
+              }
+            }}
+            enableNodeDrag={false}
             onNodeHover={handleHoverNode}
             onLinkHover={handleHoverLink}
             height={divSize.height}


### PR DESCRIPTION
## Issue
- https://github.com/oqtopus-team/oqtopus-admin/issues/6
- https://github.com/oqtopus-team/oqtopus-admin/issues/9

## Remarks
- This PR corresponds to https://github.com/oqtopus-team/oqtopus-frontend/pull/30 in frontend
- There are three changes in the topology panel.
    1. Improve visibility of selected nodes/edges on topology graph. (#6 )
    2. Fix the graph so that nodes cannot be manipulated on the screen. (#6 )
    3. Topology index changed from physical_id to id. (#9 )