### PR TITLE
refactor: simplify createCouplingMapKey and update qubit label format

### DIFF
--- a/src/device/_components/TopologyInfo.tsx
+++ b/src/device/_components/TopologyInfo.tsx
@@ -59,11 +59,8 @@ const normalizePositions = <NodeType,>(
 };
 
 const createCouplingMapKey = (control: number, target: number): string => {
-  if (control > target) {
-    return `${target}-${control}`;
-  } else {
-    return `${control}-${target}`;
-  }
+  const [first, second] = [control, target].sort((a, b) => a - b);
+  return `${first}-${second}`;
 };
 
 const createNodeData = (
@@ -79,7 +76,7 @@ const createNodeData = (
       tempNodeMap.set(qubit.id.toString(), qubit);
       return {
         id: qubit.id.toString(),
-        label: `Q${qubit.id}`,
+        label: `${qubit.id}`,
         fx: scalePosition(qubit.position.x),
         fy: scalePosition(qubit.position.y * -1), // multiply by -1 to flip the y-axis
       };


### PR DESCRIPTION
## Issue
* https://github.com/oqtopus-team/oqtopus-admin/issues/12

## Remarks
- partially revised the logic in creating the topology graph
- Changed the representation from "Q2" to "2", because the number "2" represents "id", not "physical_id"

## ScreenShot
![image](https://github.com/user-attachments/assets/cedca70f-f27e-4652-b9c0-e13218917dca)
