### PR TITLE
chore: Update announcements translation

### DIFF
--- a/src/i18n/ja/sidebar.ts
+++ b/src/i18n/ja/sidebar.ts
@@ -2,5 +2,5 @@ export default {
   users: 'ユーザー',
   white_list: 'ホワイトリスト',
   device: 'デバイス',
-  announcements: 'ニュース',
+  announcements: 'お知らせ',
 };


### PR DESCRIPTION
- Renaming "ニュース" to "お知らせ" at sidebar
