### PR TITLE
Support storage-backed device_info in admin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oqtopus-admin",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oqtopus-admin",
-      "version": "1.3.1",
+      "version": "1.3.3",
       "dependencies": {
         "@hookform/resolvers": "^5.2.1",
         "@lexical/code": "^0.34.0",
@@ -23,6 +23,7 @@
         "email-validator": "^2.0.4",
         "i18next": "^25.4.0",
         "i18next-browser-languagedetector": "^8.2.0",
+        "jszip": "^3.10.1",
         "lexical": "^0.34.0",
         "qrcode.react": "^4.1.0",
         "react": "19.1.1",
@@ -5452,6 +5453,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.84.1.tgz",
       "integrity": "sha512-sJoDunzhci8ZsqxlUiKoLut4xQeQcmbIgvDHGQKeBz6uEq9HgU+hCWOijMRr6sLP0slQVfBAza34Rq7IbXZZOA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1"
@@ -5556,6 +5558,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5564,13 +5567,15 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6477,7 +6482,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -6643,6 +6647,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -6655,6 +6660,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
       "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -6667,6 +6673,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
       },
@@ -6679,6 +6686,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
       "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -6694,6 +6702,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
       "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
       },
@@ -6709,6 +6718,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -6721,6 +6731,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -6733,6 +6744,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
       "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -6745,6 +6757,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -6757,6 +6770,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
       "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -6769,6 +6783,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -6781,6 +6796,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -6793,6 +6809,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
       "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -6805,6 +6822,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
       "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -6820,6 +6838,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
       "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -6923,6 +6942,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -6934,7 +6954,8 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.2",
@@ -6943,6 +6964,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -6953,7 +6975,8 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -6962,6 +6985,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -6972,7 +6996,8 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -7682,6 +7707,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
       "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7691,6 +7717,7 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
       "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
@@ -7707,6 +7734,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -7716,6 +7744,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -7729,6 +7758,7 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
       "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -7742,6 +7772,7 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -7754,6 +7785,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -7769,6 +7801,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -7781,6 +7814,7 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7790,6 +7824,7 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7799,6 +7834,7 @@
       "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
       "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3"
       },
@@ -7811,6 +7847,7 @@
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
       "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7826,6 +7863,7 @@
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
       "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@sinonjs/fake-timers": "^10.0.2",
@@ -7843,6 +7881,7 @@
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -7855,6 +7894,7 @@
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
       "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -7881,6 +7921,7 @@
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -7927,6 +7968,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -8237,7 +8279,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -8263,6 +8304,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.84.1.tgz",
       "integrity": "sha512-lAJ6PDZv95FdT9s9uhc9ivhikW1Zwh4j9XdXM7J2l4oUA3t37qfoBmTSDLuPyE3Bi+Xtwa11hJm0BUTT2sc/gg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20.19.4"
       }
@@ -8272,6 +8314,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.84.1.tgz",
       "integrity": "sha512-n1RIU0QAavgCg1uC5+s53arL7/mpM+16IBhJ3nCFSd/iK5tUmCwxQDcIDC703fuXfpub/ZygeSjVN8bcOWn0gA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
         "@babel/parser": "^7.25.3",
@@ -8293,6 +8336,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.84.1.tgz",
       "integrity": "sha512-f6a+mJEJ6Joxlt/050TqYUr7uRRbeKnz8lnpL7JajhpsgZLEbkJRjH8HY5QiLcRdUwWFtizml4V+vcO3P4RxoQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-native/dev-middleware": "0.84.1",
         "debug": "^4.4.0",
@@ -8323,6 +8367,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8335,6 +8380,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.84.1.tgz",
       "integrity": "sha512-rUU/Pyh3R5zT0WkVgB+yA6VwOp7HM5Hz4NYE97ajFS07OUIcv8JzBL3MXVdSSjLfldfqOuPEuKUaZcAOwPgabw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">= 20.19.4"
       }
@@ -8344,6 +8390,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.84.1.tgz",
       "integrity": "sha512-LIGhh4q4ette3yW5OzmukNMYwmINYrRGDZqKyTYc/VZyNpblZPw72coXVHXdfpPT6+YlxHqXzn3UjFZpNODGCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "debug": "^4.4.0",
@@ -8358,6 +8405,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.84.1.tgz",
       "integrity": "sha512-Z83ra+Gk6ElAhH3XRrv3vwbwCPTb04sPPlNpotxcFZb5LtRQZwT91ZQEXw3GOJCVIFp9EQ/gj8AQbVvtHKOUlQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
         "@react-native/debugger-frontend": "0.84.1",
@@ -8381,6 +8429,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.84.1.tgz",
       "integrity": "sha512-7uVlPBE3uluRNRX4MW7PUJIO1LDBTpAqStKHU7LHH+GRrdZbHsWtOEAX8PiY4GFfBEvG8hEjiuTOqAxMjV+hDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20.19.4"
       }
@@ -8390,6 +8439,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.84.1.tgz",
       "integrity": "sha512-UsTe2AbUugsfyI7XIHMQq4E7xeC8a6GrYwuK+NohMMMJMxmyM3JkzIk+GB9e2il6ScEQNMJNaj+q+i5za8itxQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20.19.4"
       }
@@ -8398,7 +8448,8 @@
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.84.1.tgz",
       "integrity": "sha512-/UPaQ4jl95soXnLDEJ6Cs6lnRXhwbxtT4KbZz+AFDees7prMV2NOLcHfCnzmTabf5Y3oxENMVBL666n4GMLcTA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@restart/hooks": {
       "version": "0.4.16",
@@ -9100,7 +9151,8 @@
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
@@ -9120,6 +9172,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -9129,6 +9182,7 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
@@ -9574,6 +9628,7 @@
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
       "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -9589,13 +9644,15 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -9605,6 +9662,7 @@
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
@@ -9636,7 +9694,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -9687,7 +9744,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/warning": {
       "version": "3.0.4",
@@ -9700,6 +9758,7 @@
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
       "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -9708,7 +9767,8 @@
       "version": "21.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
@@ -9736,6 +9796,7 @@
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -9748,6 +9809,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -9761,6 +9823,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -9770,6 +9833,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -9795,7 +9859,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9827,6 +9890,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -9865,13 +9929,15 @@
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
       "integrity": "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9896,6 +9962,7 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -9909,6 +9976,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -10065,7 +10133,8 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -10136,6 +10205,7 @@
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -10157,6 +10227,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
       "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -10173,6 +10244,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
       "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/template": "^7.3.3",
         "@babel/types": "^7.3.3",
@@ -10188,6 +10260,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.0.tgz",
       "integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hermes-parser": "0.32.0"
       }
@@ -10197,6 +10270,7 @@
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
       "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -10223,6 +10297,7 @@
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
       "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0"
@@ -10328,6 +10403,7 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -10354,7 +10430,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -10374,6 +10449,7 @@
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "node-int64": "^0.4.0"
       }
@@ -10393,7 +10469,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cac": {
       "version": "7.0.0",
@@ -10555,6 +10632,7 @@
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
       "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "escape-string-regexp": "^4.0.0",
@@ -10573,6 +10651,7 @@
       "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.2.0.tgz",
       "integrity": "sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "escape-string-regexp": "^4.0.0",
@@ -10593,6 +10672,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10608,6 +10688,7 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -10670,6 +10751,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10685,6 +10767,7 @@
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
       "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "2.6.9",
         "finalhandler": "1.1.2",
@@ -10700,6 +10783,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -10708,7 +10792,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -10728,6 +10813,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
     },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
@@ -10938,7 +11029,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11149,6 +11239,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -11167,6 +11258,7 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -11254,7 +11346,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.332",
@@ -11274,13 +11367,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -11309,6 +11404,7 @@
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
       "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "stackframe": "^1.3.4"
       }
@@ -11501,7 +11597,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -11550,7 +11645,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -11570,7 +11666,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11740,6 +11835,7 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -11806,6 +11902,7 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -11815,6 +11912,7 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -11859,7 +11957,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/fast-base64-decode": {
       "version": "1.0.0",
@@ -11908,6 +12007,7 @@
       "resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
       "integrity": "sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==",
       "license": "(MIT OR Apache-2.0)",
+      "peer": true,
       "bin": {
         "dotslash": "bin/dotslash"
       },
@@ -11920,6 +12020,7 @@
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
       "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "bser": "2.1.1"
       }
@@ -11981,6 +12082,7 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -11993,6 +12095,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -12011,6 +12114,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -12019,7 +12123,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -12077,7 +12182,8 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz",
       "integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -12171,6 +12277,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12179,7 +12286,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -12259,6 +12367,7 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -12292,6 +12401,7 @@
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -12350,6 +12460,7 @@
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -12424,7 +12535,8 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/graphql": {
       "version": "15.8.0",
@@ -12529,19 +12641,22 @@
       "version": "250829098.0.9",
       "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.9.tgz",
       "integrity": "sha512-hZ5O7PDz1vQ99TS7HD3FJ9zVynfU1y+VWId6U1Pldvd8hmAYrNec/XLPYJKD3dLOW6NXak6aAQAuMuSo3ji0tQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/hermes-estree": {
       "version": "0.32.0",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
       "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/hermes-parser": {
       "version": "0.32.0",
       "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
       "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hermes-estree": "0.32.0"
       }
@@ -12560,6 +12675,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -12580,6 +12696,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -12589,6 +12706,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -12626,7 +12744,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -12689,6 +12806,7 @@
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
       "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "queue": "6.0.2"
       },
@@ -12698,6 +12816,12 @@
       "engines": {
         "node": ">=16.x"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/immer": {
       "version": "9.0.6",
@@ -12750,6 +12874,7 @@
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -12941,6 +13066,7 @@
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -12982,6 +13108,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -13050,6 +13177,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -13260,6 +13388,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -13294,6 +13423,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -13304,6 +13434,7 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -13313,6 +13444,7 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
       "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.12.3",
         "@babel/parser": "^7.14.7",
@@ -13356,6 +13488,7 @@
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
       "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
@@ -13373,6 +13506,7 @@
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -13382,6 +13516,7 @@
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
       "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -13407,6 +13542,7 @@
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^29.6.3",
@@ -13427,6 +13563,7 @@
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
       "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -13441,6 +13578,7 @@
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -13450,6 +13588,7 @@
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
       "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -13467,6 +13606,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -13479,6 +13619,7 @@
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
       "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "camelcase": "^6.2.0",
@@ -13496,6 +13637,7 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -13508,6 +13650,7 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
       "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "jest-util": "^29.7.0",
@@ -13523,6 +13666,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -13562,7 +13706,8 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz",
       "integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -13632,6 +13777,24 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/kapsule": {
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
@@ -13659,6 +13822,7 @@
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -13688,6 +13852,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -13704,11 +13869,21 @@
         "url": "https://github.com/sponsors/dmonad"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lighthouse-logger": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
       "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "debug": "^2.6.9",
         "marky": "^1.2.2"
@@ -13719,6 +13894,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -13727,7 +13903,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -14036,7 +14213,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -14081,6 +14259,7 @@
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
       "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "tmpl": "1.0.5"
       }
@@ -14101,7 +14280,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
       "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -14116,19 +14296,22 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/metro": {
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.5.tgz",
       "integrity": "sha512-BgsXevY1MBac/3ZYv/RfNFf/4iuW9X7f4H8ZNkiH+r667HD9sVujxcmu4jvEzGCAm4/WyKdZCuyhAcyhTHOucQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/core": "^7.25.2",
@@ -14183,6 +14366,7 @@
       "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.5.tgz",
       "integrity": "sha512-d9FfmgUEVejTiSb7bkQeLRGl6aeno2UpuPm3bo3rCYwxewj03ymvOn8s8vnS4fBqAPQ+cE9iQM40wh7nGXR+eA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
@@ -14197,13 +14381,15 @@
       "version": "0.33.3",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.33.3.tgz",
       "integrity": "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
       "version": "0.33.3",
       "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz",
       "integrity": "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hermes-estree": "0.33.3"
       }
@@ -14213,6 +14399,7 @@
       "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.5.tgz",
       "integrity": "sha512-oH+s4U+IfZyg8J42bne2Skc90rcuESIYf86dYittcdWQtPfcaFXWpByPyTuWk3rR1Zz3Eh5HOrcVImfEhhJLng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
@@ -14228,6 +14415,7 @@
       "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.5.tgz",
       "integrity": "sha512-Ycl8PBajB7bhbAI7Rt0xEyiF8oJ0RWX8EKkolV1KfCUlC++V/GStMSGpPLwnnBZXZWkCC5edBPzv1Hz1Yi0Euw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
@@ -14240,6 +14428,7 @@
       "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.5.tgz",
       "integrity": "sha512-JQ/PAASXH7yczgV6OCUSRhZYME+NU8NYjI2RcaG5ga4QfQ3T/XdiLzpSb3awWZYlDCcQb36l4Vl7i0Zw7/Tf9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "connect": "^3.6.5",
         "flow-enums-runtime": "^0.0.6",
@@ -14259,6 +14448,7 @@
       "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.5.tgz",
       "integrity": "sha512-YcVcLCrf0ed4mdLa82Qob0VxYqfhmlRxUS8+TO4gosZo/gLwSvtdeOjc/Vt0pe/lvMNrBap9LlmvZM8FIsMgJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
@@ -14273,6 +14463,7 @@
       "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.5.tgz",
       "integrity": "sha512-ZEt8s3a1cnYbn40nyCD+CsZdYSlwtFh2kFym4lo+uvfM+UMMH+r/BsrC6rbNClSrt+B7rU9T+Te/sh/NL8ZZKQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "fb-watchman": "^2.0.0",
@@ -14293,6 +14484,7 @@
       "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.5.tgz",
       "integrity": "sha512-Toe4Md1wS1PBqbvB0cFxBzKEVyyuYTUb0sgifAZh/mSvLH84qA1NAWik9sISWatzvfWf3rOGoUoO5E3f193a3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "terser": "^5.15.0"
@@ -14306,6 +14498,7 @@
       "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.5.tgz",
       "integrity": "sha512-7p3GtzVUpbAweJeCcUJihJeOQl1bDuimO5ueo1K0BUpUtR41q5EilbQ3klt16UTPPMpA+tISWBtsrqU556mY1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
@@ -14318,6 +14511,7 @@
       "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.5.tgz",
       "integrity": "sha512-f+b3ue9AWTVlZe2Xrki6TAoFtKIqw30jwfk7GQ1rDUBQaE0ZQ+NkiMEtb9uwH7uAjJ87U7Tdx1Jg1OJqUfEVlA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "flow-enums-runtime": "^0.0.6"
@@ -14331,6 +14525,7 @@
       "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.5.tgz",
       "integrity": "sha512-VT9bb2KO2/4tWY9Z2yeZqTUao7CicKAOps9LUg2aQzsz+04QyuXL3qgf1cLUVRjA/D6G5u1RJAlN1w9VNHtODQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -14351,6 +14546,7 @@
       "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.5.tgz",
       "integrity": "sha512-EMIkrjNRz/hF+p0RDdxoE60+dkaTLPN3vaaGkFmX5lvFdO6HPfHA/Ywznzkev+za0VhPQ5KSdz49/MALBRteHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
@@ -14371,6 +14567,7 @@
       "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.5.tgz",
       "integrity": "sha512-KxYKzZL+lt3Os5H2nx7YkbkWVduLZL5kPrE/Yq+Prm/DE1VLhpfnO6HtPs8vimYFKOa58ncl60GpoX0h7Wm0Vw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
         "@babel/generator": "^7.29.1",
@@ -14388,6 +14585,7 @@
       "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.5.tgz",
       "integrity": "sha512-8N4pjkNXc6ytlP9oAM6MwqkvUepNSW39LKYl9NjUMpRDazBQ7oBpQDc8Sz4aI8jnH6AGhF7s1m/ayxkN1t04yA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
         "@babel/generator": "^7.29.1",
@@ -14411,19 +14609,22 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/metro/node_modules/hermes-estree": {
       "version": "0.33.3",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.33.3.tgz",
       "integrity": "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/metro/node_modules/hermes-parser": {
       "version": "0.33.3",
       "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz",
       "integrity": "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hermes-estree": "0.33.3"
       }
@@ -14433,6 +14634,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -14442,6 +14644,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -14458,6 +14661,7 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -14471,6 +14675,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -14483,6 +14688,7 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -14528,6 +14734,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -14572,6 +14779,7 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -14637,7 +14845,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-releases": {
       "version": "2.0.37",
@@ -14650,6 +14859,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14688,13 +14898,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ob1": {
       "version": "0.83.5",
       "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.5.tgz",
       "integrity": "sha512-vNKPYC8L5ycVANANpF/S+WZHpfnRWKx/F3AYP4QMn6ZJTh+l2HOrId0clNkEmua58NB9vmI9Qh7YOoV/4folYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
@@ -14824,6 +15036,7 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -14836,6 +15049,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
       "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -14845,6 +15059,7 @@
       "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
       "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
@@ -14929,6 +15144,7 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -14995,6 +15211,7 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -15013,6 +15230,7 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15073,6 +15291,7 @@
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -15157,6 +15376,7 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -15171,6 +15391,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15182,7 +15403,8 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -15209,11 +15431,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/promise": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
       "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "asap": "~2.0.6"
       }
@@ -15296,6 +15525,7 @@
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
       "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "~2.0.3"
       }
@@ -15314,6 +15544,7 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -15323,7 +15554,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15379,6 +15609,7 @@
       "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.5.tgz",
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -15389,7 +15620,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -15435,7 +15665,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
       "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -15621,6 +15850,21 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -15648,7 +15892,8 @@
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -15676,6 +15921,7 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15720,6 +15966,7 @@
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -15843,6 +16090,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -15905,6 +16158,7 @@
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
       "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -15929,6 +16183,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -15937,13 +16192,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/send/node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -15953,6 +16210,7 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -15965,6 +16223,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -15974,6 +16233,7 @@
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15983,6 +16243,7 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
       "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
@@ -15998,6 +16259,7 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -16057,11 +16319,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -16089,6 +16358,7 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
       "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -16208,6 +16478,7 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -16235,6 +16506,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16254,6 +16526,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -16264,6 +16537,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16272,7 +16546,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/ssf": {
       "version": "0.11.2",
@@ -16291,6 +16566,7 @@
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -16303,6 +16579,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -16311,13 +16588,15 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/stacktrace-parser": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
       "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "type-fest": "^0.7.1"
       },
@@ -16330,6 +16609,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
       "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -16339,6 +16619,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -16357,11 +16638,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -16474,6 +16765,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -16562,6 +16854,7 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -16579,13 +16872,15 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
       "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
@@ -16599,7 +16894,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/throttle-debounce": {
       "version": "2.3.0",
@@ -16642,13 +16938,15 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -16661,6 +16959,7 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -16701,6 +17000,7 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -16801,7 +17101,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16902,6 +17201,7 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -16975,11 +17275,18 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "license": "MIT"
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -17000,7 +17307,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -17190,7 +17496,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/void-elements": {
       "version": "3.1.0",
@@ -17206,6 +17513,7 @@
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "makeerror": "1.0.12"
       }
@@ -17229,7 +17537,8 @@
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -17385,6 +17694,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -17401,13 +17711,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -17420,13 +17732,15 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -17469,6 +17783,7 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -17484,6 +17799,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -17499,6 +17815,7 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -17517,6 +17834,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "email-validator": "^2.0.4",
     "i18next": "^25.4.0",
     "i18next-browser-languagedetector": "^8.2.0",
+    "jszip": "^3.10.1",
     "lexical": "^0.34.0",
     "qrcode.react": "^4.1.0",
     "react": "19.1.1",

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -416,7 +416,7 @@ paths:
           required: true
           schema:
             type: string
-          example: Kawasaki
+          example: qulacs
       responses:
         '200':
           description: device response
@@ -451,7 +451,7 @@ paths:
           required: true
           schema:
             type: string
-            example: Kawasaki
+            example: qulacs
       requestBody:
         description: New calibration data
         content:
@@ -510,7 +510,7 @@ paths:
           required: true
           schema:
             type: string
-            example: Kawasaki
+            example: qulacs
       responses:
         '204':
           description: Device deleted
@@ -546,6 +546,52 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error.InternalServerError'
+              example:
+                message: Internal server error
+  /devices/{device_id}/device_info/upload:
+    get:
+      tags:
+        - devices
+      summary: Generate a presigned URL to upload device_info
+      description: Generate a presigned URL to upload device_info for the selected device.
+      operationId: get_device_info_upload_url
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: device_id
+          description: Device ID
+          required: true
+          schema:
+            type: string
+            example: qulacs
+      responses:
+        '200':
+          description: Device_info upload URL generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/devices.DeviceInfoUploadResponse'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Not authorized
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error.NotFoundError'
+              example:
+                message: Device not found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error.InternalServerError'
+              example:
+                message: Internal server error
   /announcements:
     get:
       tags:
@@ -1118,7 +1164,7 @@ components:
       properties:
         device_info:
           type: string
-          example: '{"device_id": "Kawasaki", "qubits": []}'
+          example: '{"device_id": "qulacs", "qubits": []}'
         device_type:
           type: string
           enum:
@@ -1180,6 +1226,26 @@ components:
         description:
           type: string
           example: Superconducting quantum computer
+    devices.DeviceInfoUploadPresignedURL:
+      type: object
+      description: Presigned URL for uploading device_info.zip to OQTOPUS cloud.
+      properties:
+        url:
+          type: string
+          example: https://oqtopus-cloud.s3.amazonaws.com/
+        fields:
+          type: object
+          additionalProperties: true
+      required:
+        - url
+        - fields
+    devices.DeviceInfoUploadResponse:
+      type: object
+      properties:
+        presigned_url:
+          $ref: '#/components/schemas/devices.DeviceInfoUploadPresignedURL'
+      required:
+        - presigned_url
     announcements.GetAnnouncementResponse:
       type: object
       properties:

--- a/src/api/generated/.openapi-generator/FILES
+++ b/src/api/generated/.openapi-generator/FILES
@@ -12,6 +12,8 @@ docs/AnnouncementsUpdateAnnouncementRequest.md
 docs/DevicesApi.md
 docs/DevicesDeviceBase.md
 docs/DevicesDeviceInfo.md
+docs/DevicesDeviceInfoUploadPresignedURL.md
+docs/DevicesDeviceInfoUploadResponse.md
 docs/ErrorBadRequestError.md
 docs/ErrorInternalServerError.md
 docs/ErrorNotFoundError.md

--- a/src/api/generated/api.ts
+++ b/src/api/generated/api.ts
@@ -12,135 +12,158 @@
  * Do not edit the class manually.
  */
 
-
 import type { Configuration } from './configuration';
 import type { AxiosPromise, AxiosInstance, RawAxiosRequestConfig } from 'axios';
 import globalAxios from 'axios';
 // Some imports not used depending on template conditions
 // @ts-ignore
-import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction, replaceWithSerializableTypeIfNeeded } from './common';
+import {
+  DUMMY_BASE_URL,
+  assertParamExists,
+  setApiKeyToObject,
+  setBasicAuthToObject,
+  setBearerAuthToObject,
+  setOAuthToObject,
+  setSearchParams,
+  serializeDataIfNeeded,
+  toPathString,
+  createRequestFunction,
+} from './common';
 import type { RequestArgs } from './base';
 // @ts-ignore
 import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError, operationServerMap } from './base';
 
 export interface AnnouncementsGetAnnouncementResponse {
-    'id': number;
-    'title': string;
-    'content': string;
-    'start_time': string;
-    'end_time': string;
-    'publishable': boolean;
-    'updated_at': string;
+  id: number;
+  title: string;
+  content: string;
+  start_time: string;
+  end_time: string;
+  publishable: boolean;
+  updated_at: string;
 }
 export interface AnnouncementsGetAnnouncementsListResponse {
-    'announcements'?: Array<AnnouncementsGetAnnouncementResponse>;
+  announcements?: Array<AnnouncementsGetAnnouncementResponse>;
 }
 /**
  * register announcement to backend
  */
 export interface AnnouncementsRegisterAnnouncementRequest {
-    'title': string;
-    'content': string;
-    'start_time': string;
-    'end_time': string;
-    'publishable': boolean;
+  title: string;
+  content: string;
+  start_time: string;
+  end_time: string;
+  publishable: boolean;
 }
 /**
  * update announcement
  */
 export interface AnnouncementsUpdateAnnouncementRequest {
-    'title'?: string;
-    'content'?: string;
-    'start_time'?: string;
-    'end_time'?: string;
-    'publishable'?: boolean;
+  title?: string;
+  content?: string;
+  start_time?: string;
+  end_time?: string;
+  publishable?: boolean;
 }
 export interface DevicesDeviceBase {
-    'device_info'?: string;
-    'device_type'?: DevicesDeviceBaseDeviceTypeEnum;
-    'status'?: DevicesDeviceBaseStatusEnum;
-    'n_qubits'?: number;
-    'available_at'?: string;
-    'calibrated_at'?: string;
-    'basis_gates'?: Array<string>;
-    'supported_instructions'?: Array<string>;
-    'description'?: string;
+  device_info?: string;
+  device_type?: DevicesDeviceBaseDeviceTypeEnum;
+  status?: DevicesDeviceBaseStatusEnum;
+  n_qubits?: number;
+  available_at?: string;
+  calibrated_at?: string;
+  basis_gates?: Array<string>;
+  supported_instructions?: Array<string>;
+  description?: string;
 }
 
 export const DevicesDeviceBaseDeviceTypeEnum = {
-    Qpu: 'QPU',
-    Simulator: 'simulator',
+  Qpu: 'QPU',
+  Simulator: 'simulator',
 } as const;
 
-export type DevicesDeviceBaseDeviceTypeEnum = typeof DevicesDeviceBaseDeviceTypeEnum[keyof typeof DevicesDeviceBaseDeviceTypeEnum];
+export type DevicesDeviceBaseDeviceTypeEnum =
+  (typeof DevicesDeviceBaseDeviceTypeEnum)[keyof typeof DevicesDeviceBaseDeviceTypeEnum];
 export const DevicesDeviceBaseStatusEnum = {
-    Available: 'available',
-    Unavailable: 'unavailable',
+  Available: 'available',
+  Unavailable: 'unavailable',
 } as const;
 
-export type DevicesDeviceBaseStatusEnum = typeof DevicesDeviceBaseStatusEnum[keyof typeof DevicesDeviceBaseStatusEnum];
+export type DevicesDeviceBaseStatusEnum =
+  (typeof DevicesDeviceBaseStatusEnum)[keyof typeof DevicesDeviceBaseStatusEnum];
 
 export interface DevicesDeviceInfo {
-    'device_id': string;
-    'device_type': DevicesDeviceInfoDeviceTypeEnum;
-    'status': DevicesDeviceInfoStatusEnum;
-    /**
-     * Parameter mandatory and valid for \'unavailable\' devices
-     */
-    'available_at'?: string;
-    'n_pending_jobs': number;
-    'n_qubits'?: number;
-    'basis_gates': Array<string>;
-    'supported_instructions': Array<string>;
-    /**
-     * json format calibration_data and n_nodes etc
-     */
-    'device_info'?: string;
-    /**
-     * Parameter available only for `QPU` devices with available calibration data
-     */
-    'calibrated_at'?: string;
-    'description': string;
+  device_id: string;
+  device_type: DevicesDeviceInfoDeviceTypeEnum;
+  status: DevicesDeviceInfoStatusEnum;
+  /**
+   * Parameter mandatory and valid for \'unavailable\' devices
+   */
+  available_at?: string;
+  n_pending_jobs: number;
+  n_qubits?: number;
+  basis_gates: Array<string>;
+  supported_instructions: Array<string>;
+  /**
+   * json format calibration_data and n_nodes etc
+   */
+  device_info?: string;
+  /**
+   * Parameter available only for `QPU` devices with available calibration data
+   */
+  calibrated_at?: string;
+  description: string;
 }
 
 export const DevicesDeviceInfoDeviceTypeEnum = {
-    Qpu: 'QPU',
-    Simulator: 'simulator',
+  Qpu: 'QPU',
+  Simulator: 'simulator',
 } as const;
 
-export type DevicesDeviceInfoDeviceTypeEnum = typeof DevicesDeviceInfoDeviceTypeEnum[keyof typeof DevicesDeviceInfoDeviceTypeEnum];
+export type DevicesDeviceInfoDeviceTypeEnum =
+  (typeof DevicesDeviceInfoDeviceTypeEnum)[keyof typeof DevicesDeviceInfoDeviceTypeEnum];
 export const DevicesDeviceInfoStatusEnum = {
-    Available: 'available',
-    Unavailable: 'unavailable',
+  Available: 'available',
+  Unavailable: 'unavailable',
 } as const;
 
-export type DevicesDeviceInfoStatusEnum = typeof DevicesDeviceInfoStatusEnum[keyof typeof DevicesDeviceInfoStatusEnum];
+export type DevicesDeviceInfoStatusEnum =
+  (typeof DevicesDeviceInfoStatusEnum)[keyof typeof DevicesDeviceInfoStatusEnum];
 
+/**
+ * Presigned URL for uploading device_info.zip to OQTOPUS cloud.
+ */
+export interface DevicesDeviceInfoUploadPresignedURL {
+  url: string;
+  fields: { [key: string]: any };
+}
+export interface DevicesDeviceInfoUploadResponse {
+  presigned_url: DevicesDeviceInfoUploadPresignedURL;
+}
 export interface ErrorBadRequestError {
-    'message': string;
+  message: string;
 }
 export interface ErrorInternalServerError {
-    'message': string;
+  message: string;
 }
 export interface ErrorNotFoundError {
-    'message': string;
+  message: string;
 }
 export interface SuccessSuccessResponse {
-    'message': string;
+  message: string;
 }
 /**
  * detail of users response
  */
 export interface UsersGetOneUserResponse {
-    'id': string;
-    'email'?: string;
-    'display_name'?: string;
-    'organization'?: string;
-    'status'?: UsersUserStatus;
-    'group_id'?: string;
-    'available_devices'?: UsersGetOneUserResponseAvailableDevices;
+  id: string;
+  email?: string;
+  display_name?: string;
+  organization?: string;
+  status?: UsersUserStatus;
+  group_id?: string;
+  available_devices?: UsersGetOneUserResponseAvailableDevices;
 }
-
 
 /**
  * @type UsersGetOneUserResponseAvailableDevices
@@ -148,433 +171,109 @@ export interface UsersGetOneUserResponse {
 export type UsersGetOneUserResponseAvailableDevices = Array<string> | string;
 
 export interface UsersGetUsersResponse {
-    'offset'?: string;
-    'limit'?: string;
-    'users'?: Array<UsersGetOneUserResponse>;
+  offset?: string;
+  limit?: string;
+  users?: Array<UsersGetOneUserResponse>;
 }
 export interface UsersUpdateUserRequest {
-    'email'?: string;
-    'display_name'?: string;
-    'organization'?: string;
-    'status'?: UsersUserStatus;
-    'group_id'?: string;
-    'available_devices'?: UsersGetOneUserResponseAvailableDevices;
+  email?: string;
+  display_name?: string;
+  organization?: string;
+  status?: UsersUserStatus;
+  group_id?: string;
+  available_devices?: UsersGetOneUserResponseAvailableDevices;
 }
-
-
 
 export const UsersUserStatus = {
-    Approved: 'approved',
-    Unapproved: 'unapproved',
-    Suspended: 'suspended',
+  Approved: 'approved',
+  Unapproved: 'unapproved',
+  Suspended: 'suspended',
 } as const;
 
-export type UsersUserStatus = typeof UsersUserStatus[keyof typeof UsersUserStatus];
-
+export type UsersUserStatus = (typeof UsersUserStatus)[keyof typeof UsersUserStatus];
 
 export interface WhitelistUsersListWhitelistUserResponse {
-    'id': number;
-    'group_id': string;
-    'email': string;
-    'display_name'?: string;
-    'organization'?: string;
-    'is_signup_completed'?: boolean;
-    'available_devices'?: UsersGetOneUserResponseAvailableDevices;
+  id: number;
+  group_id: string;
+  email: string;
+  display_name?: string;
+  organization?: string;
+  is_signup_completed?: boolean;
+  available_devices?: UsersGetOneUserResponseAvailableDevices;
 }
 export interface WhitelistUsersListWhitelistUsersResponse {
-    'users'?: Array<WhitelistUsersListWhitelistUserResponse>;
+  users?: Array<WhitelistUsersListWhitelistUserResponse>;
 }
 /**
  * Whitelist user register request
  */
 export interface WhitelistUsersRegisterWhitelistUserRequest {
-    'group_id'?: string;
-    'email'?: string;
-    'display_name'?: string;
-    'organization'?: string;
-    'available_devices'?: UsersGetOneUserResponseAvailableDevices;
+  group_id?: string;
+  email?: string;
+  display_name?: string;
+  organization?: string;
+  available_devices?: UsersGetOneUserResponseAvailableDevices;
 }
 export interface WhitelistUsersRegisterWhitelistUsersRequest {
-    'users'?: Array<WhitelistUsersRegisterWhitelistUserRequest>;
+  users?: Array<WhitelistUsersRegisterWhitelistUserRequest>;
 }
 export interface WhitelistUsersWhitelistUsersDeleteRequest {
-    'user_emails'?: Array<string>;
+  user_emails?: Array<string>;
 }
 
 /**
  * AnnouncementsApi - axios parameter creator
  */
 export const AnnouncementsApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * Register announcement to backend
-         * @summary Register announcement to backend
-         * @param {AnnouncementsRegisterAnnouncementRequest} [announcementsRegisterAnnouncementRequest] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        announcement: async (announcementsRegisterAnnouncementRequest?: AnnouncementsRegisterAnnouncementRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/announcements`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(announcementsRegisterAnnouncementRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Delete announcement
-         * @summary Delete announcement
-         * @param {number} announcementId announcement ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteAnnouncement: async (announcementId: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'announcementId' is not null or undefined
-            assertParamExists('deleteAnnouncement', 'announcementId', announcementId)
-            const localVarPath = `/announcements/{announcement_id}`
-                .replace(`{${"announcement_id"}}`, encodeURIComponent(String(announcementId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Get selected announcement
-         * @summary Get selected announcement
-         * @param {number} announcementId announcement ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getAnnouncement: async (announcementId: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'announcementId' is not null or undefined
-            assertParamExists('getAnnouncement', 'announcementId', announcementId)
-            const localVarPath = `/announcements/{announcement_id}`
-                .replace(`{${"announcement_id"}}`, encodeURIComponent(String(announcementId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Get announcements list from backend
-         * @summary Get announcements list from backend
-         * @param {string} [offset] offset information
-         * @param {string} [limit] Limit information
-         * @param {GetAnnouncementsListOrderEnum} [order] Specify order according to start time
-         * @param {string} [currentTime] Allows to filter the list of announcements to fetch by provided time. If specified only announcements with start_time &lt;&#x3D; current_time and end_time &gt;&#x3D; current_time are returned.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getAnnouncementsList: async (offset?: string, limit?: string, order?: GetAnnouncementsListOrderEnum, currentTime?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/announcements`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            if (offset !== undefined) {
-                localVarQueryParameter['offset'] = offset;
-            }
-
-            if (limit !== undefined) {
-                localVarQueryParameter['limit'] = limit;
-            }
-
-            if (order !== undefined) {
-                localVarQueryParameter['order'] = order;
-            }
-
-            if (currentTime !== undefined) {
-                localVarQueryParameter['current_time'] = (currentTime as any instanceof Date) ?
-                    (currentTime as any).toISOString() :
-                    currentTime;
-            }
-
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Update the properties of selected announcement.
-         * @summary Update data of selected announcement
-         * @param {number} announcementId announcement ID
-         * @param {AnnouncementsUpdateAnnouncementRequest} [announcementsUpdateAnnouncementRequest] New announcement data
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateAnnouncement: async (announcementId: number, announcementsUpdateAnnouncementRequest?: AnnouncementsUpdateAnnouncementRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'announcementId' is not null or undefined
-            assertParamExists('updateAnnouncement', 'announcementId', announcementId)
-            const localVarPath = `/announcements/{announcement_id}`
-                .replace(`{${"announcement_id"}}`, encodeURIComponent(String(announcementId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(announcementsUpdateAnnouncementRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
-};
-
-/**
- * AnnouncementsApi - functional programming interface
- */
-export const AnnouncementsApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = AnnouncementsApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * Register announcement to backend
-         * @summary Register announcement to backend
-         * @param {AnnouncementsRegisterAnnouncementRequest} [announcementsRegisterAnnouncementRequest] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async announcement(announcementsRegisterAnnouncementRequest?: AnnouncementsRegisterAnnouncementRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SuccessSuccessResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.announcement(announcementsRegisterAnnouncementRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['AnnouncementsApi.announcement']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Delete announcement
-         * @summary Delete announcement
-         * @param {number} announcementId announcement ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async deleteAnnouncement(announcementId: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SuccessSuccessResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteAnnouncement(announcementId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['AnnouncementsApi.deleteAnnouncement']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Get selected announcement
-         * @summary Get selected announcement
-         * @param {number} announcementId announcement ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getAnnouncement(announcementId: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AnnouncementsGetAnnouncementResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getAnnouncement(announcementId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['AnnouncementsApi.getAnnouncement']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Get announcements list from backend
-         * @summary Get announcements list from backend
-         * @param {string} [offset] offset information
-         * @param {string} [limit] Limit information
-         * @param {GetAnnouncementsListOrderEnum} [order] Specify order according to start time
-         * @param {string} [currentTime] Allows to filter the list of announcements to fetch by provided time. If specified only announcements with start_time &lt;&#x3D; current_time and end_time &gt;&#x3D; current_time are returned.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getAnnouncementsList(offset?: string, limit?: string, order?: GetAnnouncementsListOrderEnum, currentTime?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AnnouncementsGetAnnouncementsListResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getAnnouncementsList(offset, limit, order, currentTime, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['AnnouncementsApi.getAnnouncementsList']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Update the properties of selected announcement.
-         * @summary Update data of selected announcement
-         * @param {number} announcementId announcement ID
-         * @param {AnnouncementsUpdateAnnouncementRequest} [announcementsUpdateAnnouncementRequest] New announcement data
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async updateAnnouncement(announcementId: number, announcementsUpdateAnnouncementRequest?: AnnouncementsUpdateAnnouncementRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SuccessSuccessResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updateAnnouncement(announcementId, announcementsUpdateAnnouncementRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['AnnouncementsApi.updateAnnouncement']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
-};
-
-/**
- * AnnouncementsApi - factory interface
- */
-export const AnnouncementsApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = AnnouncementsApiFp(configuration)
-    return {
-        /**
-         * Register announcement to backend
-         * @summary Register announcement to backend
-         * @param {AnnouncementsRegisterAnnouncementRequest} [announcementsRegisterAnnouncementRequest] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        announcement(announcementsRegisterAnnouncementRequest?: AnnouncementsRegisterAnnouncementRequest, options?: RawAxiosRequestConfig): AxiosPromise<SuccessSuccessResponse> {
-            return localVarFp.announcement(announcementsRegisterAnnouncementRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Delete announcement
-         * @summary Delete announcement
-         * @param {number} announcementId announcement ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteAnnouncement(announcementId: number, options?: RawAxiosRequestConfig): AxiosPromise<SuccessSuccessResponse> {
-            return localVarFp.deleteAnnouncement(announcementId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Get selected announcement
-         * @summary Get selected announcement
-         * @param {number} announcementId announcement ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getAnnouncement(announcementId: number, options?: RawAxiosRequestConfig): AxiosPromise<AnnouncementsGetAnnouncementResponse> {
-            return localVarFp.getAnnouncement(announcementId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Get announcements list from backend
-         * @summary Get announcements list from backend
-         * @param {string} [offset] offset information
-         * @param {string} [limit] Limit information
-         * @param {GetAnnouncementsListOrderEnum} [order] Specify order according to start time
-         * @param {string} [currentTime] Allows to filter the list of announcements to fetch by provided time. If specified only announcements with start_time &lt;&#x3D; current_time and end_time &gt;&#x3D; current_time are returned.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getAnnouncementsList(offset?: string, limit?: string, order?: GetAnnouncementsListOrderEnum, currentTime?: string, options?: RawAxiosRequestConfig): AxiosPromise<AnnouncementsGetAnnouncementsListResponse> {
-            return localVarFp.getAnnouncementsList(offset, limit, order, currentTime, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Update the properties of selected announcement.
-         * @summary Update data of selected announcement
-         * @param {number} announcementId announcement ID
-         * @param {AnnouncementsUpdateAnnouncementRequest} [announcementsUpdateAnnouncementRequest] New announcement data
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateAnnouncement(announcementId: number, announcementsUpdateAnnouncementRequest?: AnnouncementsUpdateAnnouncementRequest, options?: RawAxiosRequestConfig): AxiosPromise<SuccessSuccessResponse> {
-            return localVarFp.updateAnnouncement(announcementId, announcementsUpdateAnnouncementRequest, options).then((request) => request(axios, basePath));
-        },
-    };
-};
-
-/**
- * AnnouncementsApi - object-oriented interface
- */
-export class AnnouncementsApi extends BaseAPI {
+  return {
     /**
      * Register announcement to backend
      * @summary Register announcement to backend
-     * @param {AnnouncementsRegisterAnnouncementRequest} [announcementsRegisterAnnouncementRequest] 
+     * @param {AnnouncementsRegisterAnnouncementRequest} [announcementsRegisterAnnouncementRequest]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public announcement(announcementsRegisterAnnouncementRequest?: AnnouncementsRegisterAnnouncementRequest, options?: RawAxiosRequestConfig) {
-        return AnnouncementsApiFp(this.configuration).announcement(announcementsRegisterAnnouncementRequest, options).then((request) => request(this.axios, this.basePath));
-    }
+    announcement: async (
+      announcementsRegisterAnnouncementRequest?: AnnouncementsRegisterAnnouncementRequest,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      const localVarPath = `/announcements`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter['Content-Type'] = 'application/json';
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        announcementsRegisterAnnouncementRequest,
+        localVarRequestOptions,
+        configuration
+      );
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
     /**
      * Delete announcement
      * @summary Delete announcement
@@ -582,10 +281,46 @@ export class AnnouncementsApi extends BaseAPI {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public deleteAnnouncement(announcementId: number, options?: RawAxiosRequestConfig) {
-        return AnnouncementsApiFp(this.configuration).deleteAnnouncement(announcementId, options).then((request) => request(this.axios, this.basePath));
-    }
+    deleteAnnouncement: async (
+      announcementId: number,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'announcementId' is not null or undefined
+      assertParamExists('deleteAnnouncement', 'announcementId', announcementId);
+      const localVarPath = `/announcements/{announcement_id}`.replace(
+        `{${'announcement_id'}}`,
+        encodeURIComponent(String(announcementId))
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
+      const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
     /**
      * Get selected announcement
      * @summary Get selected announcement
@@ -593,10 +328,46 @@ export class AnnouncementsApi extends BaseAPI {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public getAnnouncement(announcementId: number, options?: RawAxiosRequestConfig) {
-        return AnnouncementsApiFp(this.configuration).getAnnouncement(announcementId, options).then((request) => request(this.axios, this.basePath));
-    }
+    getAnnouncement: async (
+      announcementId: number,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'announcementId' is not null or undefined
+      assertParamExists('getAnnouncement', 'announcementId', announcementId);
+      const localVarPath = `/announcements/{announcement_id}`.replace(
+        `{${'announcement_id'}}`,
+        encodeURIComponent(String(announcementId))
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
     /**
      * Get announcements list from backend
      * @summary Get announcements list from backend
@@ -607,10 +378,61 @@ export class AnnouncementsApi extends BaseAPI {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public getAnnouncementsList(offset?: string, limit?: string, order?: GetAnnouncementsListOrderEnum, currentTime?: string, options?: RawAxiosRequestConfig) {
-        return AnnouncementsApiFp(this.configuration).getAnnouncementsList(offset, limit, order, currentTime, options).then((request) => request(this.axios, this.basePath));
-    }
+    getAnnouncementsList: async (
+      offset?: string,
+      limit?: string,
+      order?: GetAnnouncementsListOrderEnum,
+      currentTime?: string,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      const localVarPath = `/announcements`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      if (offset !== undefined) {
+        localVarQueryParameter['offset'] = offset;
+      }
+
+      if (limit !== undefined) {
+        localVarQueryParameter['limit'] = limit;
+      }
+
+      if (order !== undefined) {
+        localVarQueryParameter['order'] = order;
+      }
+
+      if (currentTime !== undefined) {
+        localVarQueryParameter['current_time'] =
+          (currentTime as any) instanceof Date ? (currentTime as any).toISOString() : currentTime;
+      }
+
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
     /**
      * Update the properties of selected announcement.
      * @summary Update data of selected announcement
@@ -619,351 +441,415 @@ export class AnnouncementsApi extends BaseAPI {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public updateAnnouncement(announcementId: number, announcementsUpdateAnnouncementRequest?: AnnouncementsUpdateAnnouncementRequest, options?: RawAxiosRequestConfig) {
-        return AnnouncementsApiFp(this.configuration).updateAnnouncement(announcementId, announcementsUpdateAnnouncementRequest, options).then((request) => request(this.axios, this.basePath));
-    }
+    updateAnnouncement: async (
+      announcementId: number,
+      announcementsUpdateAnnouncementRequest?: AnnouncementsUpdateAnnouncementRequest,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'announcementId' is not null or undefined
+      assertParamExists('updateAnnouncement', 'announcementId', announcementId);
+      const localVarPath = `/announcements/{announcement_id}`.replace(
+        `{${'announcement_id'}}`,
+        encodeURIComponent(String(announcementId))
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+
+      const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter['Content-Type'] = 'application/json';
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        announcementsUpdateAnnouncementRequest,
+        localVarRequestOptions,
+        configuration
+      );
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+  };
+};
+
+/**
+ * AnnouncementsApi - functional programming interface
+ */
+export const AnnouncementsApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator = AnnouncementsApiAxiosParamCreator(configuration);
+  return {
+    /**
+     * Register announcement to backend
+     * @summary Register announcement to backend
+     * @param {AnnouncementsRegisterAnnouncementRequest} [announcementsRegisterAnnouncementRequest]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async announcement(
+      announcementsRegisterAnnouncementRequest?: AnnouncementsRegisterAnnouncementRequest,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SuccessSuccessResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.announcement(
+        announcementsRegisterAnnouncementRequest,
+        options
+      );
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['AnnouncementsApi.announcement']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Delete announcement
+     * @summary Delete announcement
+     * @param {number} announcementId announcement ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async deleteAnnouncement(
+      announcementId: number,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SuccessSuccessResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.deleteAnnouncement(
+        announcementId,
+        options
+      );
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['AnnouncementsApi.deleteAnnouncement']?.[localVarOperationServerIndex]
+          ?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Get selected announcement
+     * @summary Get selected announcement
+     * @param {number} announcementId announcement ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getAnnouncement(
+      announcementId: number,
+      options?: RawAxiosRequestConfig
+    ): Promise<
+      (
+        axios?: AxiosInstance,
+        basePath?: string
+      ) => AxiosPromise<AnnouncementsGetAnnouncementResponse>
+    > {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.getAnnouncement(
+        announcementId,
+        options
+      );
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['AnnouncementsApi.getAnnouncement']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Get announcements list from backend
+     * @summary Get announcements list from backend
+     * @param {string} [offset] offset information
+     * @param {string} [limit] Limit information
+     * @param {GetAnnouncementsListOrderEnum} [order] Specify order according to start time
+     * @param {string} [currentTime] Allows to filter the list of announcements to fetch by provided time. If specified only announcements with start_time &lt;&#x3D; current_time and end_time &gt;&#x3D; current_time are returned.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getAnnouncementsList(
+      offset?: string,
+      limit?: string,
+      order?: GetAnnouncementsListOrderEnum,
+      currentTime?: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<
+      (
+        axios?: AxiosInstance,
+        basePath?: string
+      ) => AxiosPromise<AnnouncementsGetAnnouncementsListResponse>
+    > {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.getAnnouncementsList(
+        offset,
+        limit,
+        order,
+        currentTime,
+        options
+      );
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['AnnouncementsApi.getAnnouncementsList']?.[localVarOperationServerIndex]
+          ?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Update the properties of selected announcement.
+     * @summary Update data of selected announcement
+     * @param {number} announcementId announcement ID
+     * @param {AnnouncementsUpdateAnnouncementRequest} [announcementsUpdateAnnouncementRequest] New announcement data
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async updateAnnouncement(
+      announcementId: number,
+      announcementsUpdateAnnouncementRequest?: AnnouncementsUpdateAnnouncementRequest,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SuccessSuccessResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.updateAnnouncement(
+        announcementId,
+        announcementsUpdateAnnouncementRequest,
+        options
+      );
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['AnnouncementsApi.updateAnnouncement']?.[localVarOperationServerIndex]
+          ?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+  };
+};
+
+/**
+ * AnnouncementsApi - factory interface
+ */
+export const AnnouncementsApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance
+) {
+  const localVarFp = AnnouncementsApiFp(configuration);
+  return {
+    /**
+     * Register announcement to backend
+     * @summary Register announcement to backend
+     * @param {AnnouncementsRegisterAnnouncementRequest} [announcementsRegisterAnnouncementRequest]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    announcement(
+      announcementsRegisterAnnouncementRequest?: AnnouncementsRegisterAnnouncementRequest,
+      options?: RawAxiosRequestConfig
+    ): AxiosPromise<SuccessSuccessResponse> {
+      return localVarFp
+        .announcement(announcementsRegisterAnnouncementRequest, options)
+        .then((request) => request(axios, basePath));
+    },
+    /**
+     * Delete announcement
+     * @summary Delete announcement
+     * @param {number} announcementId announcement ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deleteAnnouncement(
+      announcementId: number,
+      options?: RawAxiosRequestConfig
+    ): AxiosPromise<SuccessSuccessResponse> {
+      return localVarFp
+        .deleteAnnouncement(announcementId, options)
+        .then((request) => request(axios, basePath));
+    },
+    /**
+     * Get selected announcement
+     * @summary Get selected announcement
+     * @param {number} announcementId announcement ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getAnnouncement(
+      announcementId: number,
+      options?: RawAxiosRequestConfig
+    ): AxiosPromise<AnnouncementsGetAnnouncementResponse> {
+      return localVarFp
+        .getAnnouncement(announcementId, options)
+        .then((request) => request(axios, basePath));
+    },
+    /**
+     * Get announcements list from backend
+     * @summary Get announcements list from backend
+     * @param {string} [offset] offset information
+     * @param {string} [limit] Limit information
+     * @param {GetAnnouncementsListOrderEnum} [order] Specify order according to start time
+     * @param {string} [currentTime] Allows to filter the list of announcements to fetch by provided time. If specified only announcements with start_time &lt;&#x3D; current_time and end_time &gt;&#x3D; current_time are returned.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getAnnouncementsList(
+      offset?: string,
+      limit?: string,
+      order?: GetAnnouncementsListOrderEnum,
+      currentTime?: string,
+      options?: RawAxiosRequestConfig
+    ): AxiosPromise<AnnouncementsGetAnnouncementsListResponse> {
+      return localVarFp
+        .getAnnouncementsList(offset, limit, order, currentTime, options)
+        .then((request) => request(axios, basePath));
+    },
+    /**
+     * Update the properties of selected announcement.
+     * @summary Update data of selected announcement
+     * @param {number} announcementId announcement ID
+     * @param {AnnouncementsUpdateAnnouncementRequest} [announcementsUpdateAnnouncementRequest] New announcement data
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    updateAnnouncement(
+      announcementId: number,
+      announcementsUpdateAnnouncementRequest?: AnnouncementsUpdateAnnouncementRequest,
+      options?: RawAxiosRequestConfig
+    ): AxiosPromise<SuccessSuccessResponse> {
+      return localVarFp
+        .updateAnnouncement(announcementId, announcementsUpdateAnnouncementRequest, options)
+        .then((request) => request(axios, basePath));
+    },
+  };
+};
+
+/**
+ * AnnouncementsApi - object-oriented interface
+ */
+export class AnnouncementsApi extends BaseAPI {
+  /**
+   * Register announcement to backend
+   * @summary Register announcement to backend
+   * @param {AnnouncementsRegisterAnnouncementRequest} [announcementsRegisterAnnouncementRequest]
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public announcement(
+    announcementsRegisterAnnouncementRequest?: AnnouncementsRegisterAnnouncementRequest,
+    options?: RawAxiosRequestConfig
+  ) {
+    return AnnouncementsApiFp(this.configuration)
+      .announcement(announcementsRegisterAnnouncementRequest, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * Delete announcement
+   * @summary Delete announcement
+   * @param {number} announcementId announcement ID
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public deleteAnnouncement(announcementId: number, options?: RawAxiosRequestConfig) {
+    return AnnouncementsApiFp(this.configuration)
+      .deleteAnnouncement(announcementId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * Get selected announcement
+   * @summary Get selected announcement
+   * @param {number} announcementId announcement ID
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public getAnnouncement(announcementId: number, options?: RawAxiosRequestConfig) {
+    return AnnouncementsApiFp(this.configuration)
+      .getAnnouncement(announcementId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * Get announcements list from backend
+   * @summary Get announcements list from backend
+   * @param {string} [offset] offset information
+   * @param {string} [limit] Limit information
+   * @param {GetAnnouncementsListOrderEnum} [order] Specify order according to start time
+   * @param {string} [currentTime] Allows to filter the list of announcements to fetch by provided time. If specified only announcements with start_time &lt;&#x3D; current_time and end_time &gt;&#x3D; current_time are returned.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public getAnnouncementsList(
+    offset?: string,
+    limit?: string,
+    order?: GetAnnouncementsListOrderEnum,
+    currentTime?: string,
+    options?: RawAxiosRequestConfig
+  ) {
+    return AnnouncementsApiFp(this.configuration)
+      .getAnnouncementsList(offset, limit, order, currentTime, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * Update the properties of selected announcement.
+   * @summary Update data of selected announcement
+   * @param {number} announcementId announcement ID
+   * @param {AnnouncementsUpdateAnnouncementRequest} [announcementsUpdateAnnouncementRequest] New announcement data
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public updateAnnouncement(
+    announcementId: number,
+    announcementsUpdateAnnouncementRequest?: AnnouncementsUpdateAnnouncementRequest,
+    options?: RawAxiosRequestConfig
+  ) {
+    return AnnouncementsApiFp(this.configuration)
+      .updateAnnouncement(announcementId, announcementsUpdateAnnouncementRequest, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 }
 
 export const GetAnnouncementsListOrderEnum = {
-    Desc: 'DESC',
-    Asc: 'ASC',
+  Desc: 'DESC',
+  Asc: 'ASC',
 } as const;
-export type GetAnnouncementsListOrderEnum = typeof GetAnnouncementsListOrderEnum[keyof typeof GetAnnouncementsListOrderEnum];
-
+export type GetAnnouncementsListOrderEnum =
+  (typeof GetAnnouncementsListOrderEnum)[keyof typeof GetAnnouncementsListOrderEnum];
 
 /**
  * DevicesApi - axios parameter creator
  */
 export const DevicesApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * Delete a device from the system.
-         * @summary Delete a device
-         * @param {string} deviceId Device ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteDevice: async (deviceId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'deviceId' is not null or undefined
-            assertParamExists('deleteDevice', 'deviceId', deviceId)
-            const localVarPath = `/devices/{device_id}`
-                .replace(`{${"device_id"}}`, encodeURIComponent(String(deviceId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * get device
-         * @summary Get specified device details
-         * @param {string} deviceId Device identifier
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getDevice: async (deviceId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'deviceId' is not null or undefined
-            assertParamExists('getDevice', 'deviceId', deviceId)
-            const localVarPath = `/devices/{device_id}`
-                .replace(`{${"device_id"}}`, encodeURIComponent(String(deviceId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * List available devices
-         * @summary List available devices
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        listDevices: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/devices`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Register a new device to the system.
-         * @summary Register a new device
-         * @param {DevicesDeviceBase} [devicesDeviceBase] Device data
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        registerDevice: async (devicesDeviceBase?: DevicesDeviceBase, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/devices`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(devicesDeviceBase, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Update the properties of selected device.
-         * @summary Update data of selected device
-         * @param {string} deviceId Device ID
-         * @param {DevicesDeviceBase} [devicesDeviceBase] New calibration data
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateDeviceData: async (deviceId: string, devicesDeviceBase?: DevicesDeviceBase, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'deviceId' is not null or undefined
-            assertParamExists('updateDeviceData', 'deviceId', deviceId)
-            const localVarPath = `/devices/{device_id}`
-                .replace(`{${"device_id"}}`, encodeURIComponent(String(deviceId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(devicesDeviceBase, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
-};
-
-/**
- * DevicesApi - functional programming interface
- */
-export const DevicesApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = DevicesApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * Delete a device from the system.
-         * @summary Delete a device
-         * @param {string} deviceId Device ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async deleteDevice(deviceId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SuccessSuccessResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteDevice(deviceId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['DevicesApi.deleteDevice']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * get device
-         * @summary Get specified device details
-         * @param {string} deviceId Device identifier
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getDevice(deviceId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<DevicesDeviceInfo>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getDevice(deviceId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['DevicesApi.getDevice']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * List available devices
-         * @summary List available devices
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async listDevices(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<DevicesDeviceInfo>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.listDevices(options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['DevicesApi.listDevices']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Register a new device to the system.
-         * @summary Register a new device
-         * @param {DevicesDeviceBase} [devicesDeviceBase] Device data
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async registerDevice(devicesDeviceBase?: DevicesDeviceBase, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SuccessSuccessResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.registerDevice(devicesDeviceBase, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['DevicesApi.registerDevice']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Update the properties of selected device.
-         * @summary Update data of selected device
-         * @param {string} deviceId Device ID
-         * @param {DevicesDeviceBase} [devicesDeviceBase] New calibration data
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async updateDeviceData(deviceId: string, devicesDeviceBase?: DevicesDeviceBase, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SuccessSuccessResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updateDeviceData(deviceId, devicesDeviceBase, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['DevicesApi.updateDeviceData']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
-};
-
-/**
- * DevicesApi - factory interface
- */
-export const DevicesApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = DevicesApiFp(configuration)
-    return {
-        /**
-         * Delete a device from the system.
-         * @summary Delete a device
-         * @param {string} deviceId Device ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteDevice(deviceId: string, options?: RawAxiosRequestConfig): AxiosPromise<SuccessSuccessResponse> {
-            return localVarFp.deleteDevice(deviceId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * get device
-         * @summary Get specified device details
-         * @param {string} deviceId Device identifier
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getDevice(deviceId: string, options?: RawAxiosRequestConfig): AxiosPromise<DevicesDeviceInfo> {
-            return localVarFp.getDevice(deviceId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * List available devices
-         * @summary List available devices
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        listDevices(options?: RawAxiosRequestConfig): AxiosPromise<Array<DevicesDeviceInfo>> {
-            return localVarFp.listDevices(options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Register a new device to the system.
-         * @summary Register a new device
-         * @param {DevicesDeviceBase} [devicesDeviceBase] Device data
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        registerDevice(devicesDeviceBase?: DevicesDeviceBase, options?: RawAxiosRequestConfig): AxiosPromise<SuccessSuccessResponse> {
-            return localVarFp.registerDevice(devicesDeviceBase, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Update the properties of selected device.
-         * @summary Update data of selected device
-         * @param {string} deviceId Device ID
-         * @param {DevicesDeviceBase} [devicesDeviceBase] New calibration data
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateDeviceData(deviceId: string, devicesDeviceBase?: DevicesDeviceBase, options?: RawAxiosRequestConfig): AxiosPromise<SuccessSuccessResponse> {
-            return localVarFp.updateDeviceData(deviceId, devicesDeviceBase, options).then((request) => request(axios, basePath));
-        },
-    };
-};
-
-/**
- * DevicesApi - object-oriented interface
- */
-export class DevicesApi extends BaseAPI {
+  return {
     /**
      * Delete a device from the system.
      * @summary Delete a device
@@ -971,10 +857,46 @@ export class DevicesApi extends BaseAPI {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public deleteDevice(deviceId: string, options?: RawAxiosRequestConfig) {
-        return DevicesApiFp(this.configuration).deleteDevice(deviceId, options).then((request) => request(this.axios, this.basePath));
-    }
+    deleteDevice: async (
+      deviceId: string,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'deviceId' is not null or undefined
+      assertParamExists('deleteDevice', 'deviceId', deviceId);
+      const localVarPath = `/devices/{device_id}`.replace(
+        `{${'device_id'}}`,
+        encodeURIComponent(String(deviceId))
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
+      const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
     /**
      * get device
      * @summary Get specified device details
@@ -982,20 +904,131 @@ export class DevicesApi extends BaseAPI {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public getDevice(deviceId: string, options?: RawAxiosRequestConfig) {
-        return DevicesApiFp(this.configuration).getDevice(deviceId, options).then((request) => request(this.axios, this.basePath));
-    }
+    getDevice: async (
+      deviceId: string,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'deviceId' is not null or undefined
+      assertParamExists('getDevice', 'deviceId', deviceId);
+      const localVarPath = `/devices/{device_id}`.replace(
+        `{${'device_id'}}`,
+        encodeURIComponent(String(deviceId))
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * Generate a presigned URL to upload device_info for the selected device.
+     * @summary Generate a presigned URL to upload device_info
+     * @param {string} deviceId Device ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getDeviceInfoUploadUrl: async (
+      deviceId: string,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'deviceId' is not null or undefined
+      assertParamExists('getDeviceInfoUploadUrl', 'deviceId', deviceId);
+      const localVarPath = `/devices/{device_id}/device_info/upload`.replace(
+        `{${'device_id'}}`,
+        encodeURIComponent(String(deviceId))
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
     /**
      * List available devices
      * @summary List available devices
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public listDevices(options?: RawAxiosRequestConfig) {
-        return DevicesApiFp(this.configuration).listDevices(options).then((request) => request(this.axios, this.basePath));
-    }
+    listDevices: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      const localVarPath = `/devices`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
     /**
      * Register a new device to the system.
      * @summary Register a new device
@@ -1003,10 +1036,47 @@ export class DevicesApi extends BaseAPI {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public registerDevice(devicesDeviceBase?: DevicesDeviceBase, options?: RawAxiosRequestConfig) {
-        return DevicesApiFp(this.configuration).registerDevice(devicesDeviceBase, options).then((request) => request(this.axios, this.basePath));
-    }
+    registerDevice: async (
+      devicesDeviceBase?: DevicesDeviceBase,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      const localVarPath = `/devices`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter['Content-Type'] = 'application/json';
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        devicesDeviceBase,
+        localVarRequestOptions,
+        configuration
+      );
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
     /**
      * Update the properties of selected device.
      * @summary Update data of selected device
@@ -1015,344 +1085,402 @@ export class DevicesApi extends BaseAPI {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public updateDeviceData(deviceId: string, devicesDeviceBase?: DevicesDeviceBase, options?: RawAxiosRequestConfig) {
-        return DevicesApiFp(this.configuration).updateDeviceData(deviceId, devicesDeviceBase, options).then((request) => request(this.axios, this.basePath));
-    }
+    updateDeviceData: async (
+      deviceId: string,
+      devicesDeviceBase?: DevicesDeviceBase,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'deviceId' is not null or undefined
+      assertParamExists('updateDeviceData', 'deviceId', deviceId);
+      const localVarPath = `/devices/{device_id}`.replace(
+        `{${'device_id'}}`,
+        encodeURIComponent(String(deviceId))
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+
+      const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter['Content-Type'] = 'application/json';
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        devicesDeviceBase,
+        localVarRequestOptions,
+        configuration
+      );
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+  };
+};
+
+/**
+ * DevicesApi - functional programming interface
+ */
+export const DevicesApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator = DevicesApiAxiosParamCreator(configuration);
+  return {
+    /**
+     * Delete a device from the system.
+     * @summary Delete a device
+     * @param {string} deviceId Device ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async deleteDevice(
+      deviceId: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SuccessSuccessResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.deleteDevice(deviceId, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['DevicesApi.deleteDevice']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * get device
+     * @summary Get specified device details
+     * @param {string} deviceId Device identifier
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getDevice(
+      deviceId: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<DevicesDeviceInfo>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.getDevice(deviceId, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['DevicesApi.getDevice']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Generate a presigned URL to upload device_info for the selected device.
+     * @summary Generate a presigned URL to upload device_info
+     * @param {string} deviceId Device ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getDeviceInfoUploadUrl(
+      deviceId: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<DevicesDeviceInfoUploadResponse>
+    > {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.getDeviceInfoUploadUrl(
+        deviceId,
+        options
+      );
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['DevicesApi.getDeviceInfoUploadUrl']?.[localVarOperationServerIndex]
+          ?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * List available devices
+     * @summary List available devices
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async listDevices(
+      options?: RawAxiosRequestConfig
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<DevicesDeviceInfo>>
+    > {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.listDevices(options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['DevicesApi.listDevices']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Register a new device to the system.
+     * @summary Register a new device
+     * @param {DevicesDeviceBase} [devicesDeviceBase] Device data
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async registerDevice(
+      devicesDeviceBase?: DevicesDeviceBase,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SuccessSuccessResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.registerDevice(
+        devicesDeviceBase,
+        options
+      );
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['DevicesApi.registerDevice']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Update the properties of selected device.
+     * @summary Update data of selected device
+     * @param {string} deviceId Device ID
+     * @param {DevicesDeviceBase} [devicesDeviceBase] New calibration data
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async updateDeviceData(
+      deviceId: string,
+      devicesDeviceBase?: DevicesDeviceBase,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SuccessSuccessResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.updateDeviceData(
+        deviceId,
+        devicesDeviceBase,
+        options
+      );
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['DevicesApi.updateDeviceData']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+  };
+};
+
+/**
+ * DevicesApi - factory interface
+ */
+export const DevicesApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance
+) {
+  const localVarFp = DevicesApiFp(configuration);
+  return {
+    /**
+     * Delete a device from the system.
+     * @summary Delete a device
+     * @param {string} deviceId Device ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deleteDevice(
+      deviceId: string,
+      options?: RawAxiosRequestConfig
+    ): AxiosPromise<SuccessSuccessResponse> {
+      return localVarFp.deleteDevice(deviceId, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * get device
+     * @summary Get specified device details
+     * @param {string} deviceId Device identifier
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getDevice(deviceId: string, options?: RawAxiosRequestConfig): AxiosPromise<DevicesDeviceInfo> {
+      return localVarFp.getDevice(deviceId, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * Generate a presigned URL to upload device_info for the selected device.
+     * @summary Generate a presigned URL to upload device_info
+     * @param {string} deviceId Device ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getDeviceInfoUploadUrl(
+      deviceId: string,
+      options?: RawAxiosRequestConfig
+    ): AxiosPromise<DevicesDeviceInfoUploadResponse> {
+      return localVarFp
+        .getDeviceInfoUploadUrl(deviceId, options)
+        .then((request) => request(axios, basePath));
+    },
+    /**
+     * List available devices
+     * @summary List available devices
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    listDevices(options?: RawAxiosRequestConfig): AxiosPromise<Array<DevicesDeviceInfo>> {
+      return localVarFp.listDevices(options).then((request) => request(axios, basePath));
+    },
+    /**
+     * Register a new device to the system.
+     * @summary Register a new device
+     * @param {DevicesDeviceBase} [devicesDeviceBase] Device data
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    registerDevice(
+      devicesDeviceBase?: DevicesDeviceBase,
+      options?: RawAxiosRequestConfig
+    ): AxiosPromise<SuccessSuccessResponse> {
+      return localVarFp
+        .registerDevice(devicesDeviceBase, options)
+        .then((request) => request(axios, basePath));
+    },
+    /**
+     * Update the properties of selected device.
+     * @summary Update data of selected device
+     * @param {string} deviceId Device ID
+     * @param {DevicesDeviceBase} [devicesDeviceBase] New calibration data
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    updateDeviceData(
+      deviceId: string,
+      devicesDeviceBase?: DevicesDeviceBase,
+      options?: RawAxiosRequestConfig
+    ): AxiosPromise<SuccessSuccessResponse> {
+      return localVarFp
+        .updateDeviceData(deviceId, devicesDeviceBase, options)
+        .then((request) => request(axios, basePath));
+    },
+  };
+};
+
+/**
+ * DevicesApi - object-oriented interface
+ */
+export class DevicesApi extends BaseAPI {
+  /**
+   * Delete a device from the system.
+   * @summary Delete a device
+   * @param {string} deviceId Device ID
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public deleteDevice(deviceId: string, options?: RawAxiosRequestConfig) {
+    return DevicesApiFp(this.configuration)
+      .deleteDevice(deviceId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * get device
+   * @summary Get specified device details
+   * @param {string} deviceId Device identifier
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public getDevice(deviceId: string, options?: RawAxiosRequestConfig) {
+    return DevicesApiFp(this.configuration)
+      .getDevice(deviceId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * Generate a presigned URL to upload device_info for the selected device.
+   * @summary Generate a presigned URL to upload device_info
+   * @param {string} deviceId Device ID
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public getDeviceInfoUploadUrl(deviceId: string, options?: RawAxiosRequestConfig) {
+    return DevicesApiFp(this.configuration)
+      .getDeviceInfoUploadUrl(deviceId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * List available devices
+   * @summary List available devices
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public listDevices(options?: RawAxiosRequestConfig) {
+    return DevicesApiFp(this.configuration)
+      .listDevices(options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * Register a new device to the system.
+   * @summary Register a new device
+   * @param {DevicesDeviceBase} [devicesDeviceBase] Device data
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public registerDevice(devicesDeviceBase?: DevicesDeviceBase, options?: RawAxiosRequestConfig) {
+    return DevicesApiFp(this.configuration)
+      .registerDevice(devicesDeviceBase, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * Update the properties of selected device.
+   * @summary Update data of selected device
+   * @param {string} deviceId Device ID
+   * @param {DevicesDeviceBase} [devicesDeviceBase] New calibration data
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public updateDeviceData(
+    deviceId: string,
+    devicesDeviceBase?: DevicesDeviceBase,
+    options?: RawAxiosRequestConfig
+  ) {
+    return DevicesApiFp(this.configuration)
+      .updateDeviceData(deviceId, devicesDeviceBase, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 }
-
-
 
 /**
  * UserApi - axios parameter creator
  */
 export const UserApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * delete user with designated id
-         * @summary delete user
-         * @param {string} userId User ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteUserById: async (userId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'userId' is not null or undefined
-            assertParamExists('deleteUserById', 'userId', userId)
-            const localVarPath = `/users/{user_id}`
-                .replace(`{${"user_id"}}`, encodeURIComponent(String(userId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * get one user
-         * @summary get one user
-         * @param {string} userId User ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getOneUserById: async (userId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'userId' is not null or undefined
-            assertParamExists('getOneUserById', 'userId', userId)
-            const localVarPath = `/users/{user_id}`
-                .replace(`{${"user_id"}}`, encodeURIComponent(String(userId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * get users
-         * @summary get users
-         * @param {string} [offset] offset information
-         * @param {string} [limit] Limit information
-         * @param {string} [userId] query user id
-         * @param {string} [email] query email information
-         * @param {string} [displayName] query display name information
-         * @param {string} [organization] query organization information
-         * @param {UsersUserStatus} [status] query user status
-         * @param {string} [groupId] query group ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getUsers: async (offset?: string, limit?: string, userId?: string, email?: string, displayName?: string, organization?: string, status?: UsersUserStatus, groupId?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/users`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            if (offset !== undefined) {
-                localVarQueryParameter['offset'] = offset;
-            }
-
-            if (limit !== undefined) {
-                localVarQueryParameter['limit'] = limit;
-            }
-
-            if (userId !== undefined) {
-                localVarQueryParameter['user_id'] = userId;
-            }
-
-            if (email !== undefined) {
-                localVarQueryParameter['email'] = email;
-            }
-
-            if (displayName !== undefined) {
-                localVarQueryParameter['display_name'] = displayName;
-            }
-
-            if (organization !== undefined) {
-                localVarQueryParameter['organization'] = organization;
-            }
-
-            if (status !== undefined) {
-                localVarQueryParameter['status'] = status;
-            }
-
-            if (groupId !== undefined) {
-                localVarQueryParameter['group_id'] = groupId;
-            }
-
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * update user status
-         * @summary update user status
-         * @param {string} userId User ID
-         * @param {UsersUpdateUserRequest} usersUpdateUserRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updatetUserStatusById: async (userId: string, usersUpdateUserRequest: UsersUpdateUserRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'userId' is not null or undefined
-            assertParamExists('updatetUserStatusById', 'userId', userId)
-            // verify required parameter 'usersUpdateUserRequest' is not null or undefined
-            assertParamExists('updatetUserStatusById', 'usersUpdateUserRequest', usersUpdateUserRequest)
-            const localVarPath = `/users/{user_id}`
-                .replace(`{${"user_id"}}`, encodeURIComponent(String(userId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(usersUpdateUserRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
-};
-
-/**
- * UserApi - functional programming interface
- */
-export const UserApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = UserApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * delete user with designated id
-         * @summary delete user
-         * @param {string} userId User ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async deleteUserById(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUserById(userId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['UserApi.deleteUserById']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * get one user
-         * @summary get one user
-         * @param {string} userId User ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getOneUserById(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<UsersGetOneUserResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getOneUserById(userId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['UserApi.getOneUserById']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * get users
-         * @summary get users
-         * @param {string} [offset] offset information
-         * @param {string} [limit] Limit information
-         * @param {string} [userId] query user id
-         * @param {string} [email] query email information
-         * @param {string} [displayName] query display name information
-         * @param {string} [organization] query organization information
-         * @param {UsersUserStatus} [status] query user status
-         * @param {string} [groupId] query group ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getUsers(offset?: string, limit?: string, userId?: string, email?: string, displayName?: string, organization?: string, status?: UsersUserStatus, groupId?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<UsersGetUsersResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getUsers(offset, limit, userId, email, displayName, organization, status, groupId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['UserApi.getUsers']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * update user status
-         * @summary update user status
-         * @param {string} userId User ID
-         * @param {UsersUpdateUserRequest} usersUpdateUserRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async updatetUserStatusById(userId: string, usersUpdateUserRequest: UsersUpdateUserRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<UsersGetOneUserResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updatetUserStatusById(userId, usersUpdateUserRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['UserApi.updatetUserStatusById']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
-};
-
-/**
- * UserApi - factory interface
- */
-export const UserApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = UserApiFp(configuration)
-    return {
-        /**
-         * delete user with designated id
-         * @summary delete user
-         * @param {string} userId User ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteUserById(userId: string, options?: RawAxiosRequestConfig): AxiosPromise<void> {
-            return localVarFp.deleteUserById(userId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * get one user
-         * @summary get one user
-         * @param {string} userId User ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getOneUserById(userId: string, options?: RawAxiosRequestConfig): AxiosPromise<UsersGetOneUserResponse> {
-            return localVarFp.getOneUserById(userId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * get users
-         * @summary get users
-         * @param {string} [offset] offset information
-         * @param {string} [limit] Limit information
-         * @param {string} [userId] query user id
-         * @param {string} [email] query email information
-         * @param {string} [displayName] query display name information
-         * @param {string} [organization] query organization information
-         * @param {UsersUserStatus} [status] query user status
-         * @param {string} [groupId] query group ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getUsers(offset?: string, limit?: string, userId?: string, email?: string, displayName?: string, organization?: string, status?: UsersUserStatus, groupId?: string, options?: RawAxiosRequestConfig): AxiosPromise<UsersGetUsersResponse> {
-            return localVarFp.getUsers(offset, limit, userId, email, displayName, organization, status, groupId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * update user status
-         * @summary update user status
-         * @param {string} userId User ID
-         * @param {UsersUpdateUserRequest} usersUpdateUserRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updatetUserStatusById(userId: string, usersUpdateUserRequest: UsersUpdateUserRequest, options?: RawAxiosRequestConfig): AxiosPromise<UsersGetOneUserResponse> {
-            return localVarFp.updatetUserStatusById(userId, usersUpdateUserRequest, options).then((request) => request(axios, basePath));
-        },
-    };
-};
-
-/**
- * UserApi - object-oriented interface
- */
-export class UserApi extends BaseAPI {
+  return {
     /**
      * delete user with designated id
      * @summary delete user
@@ -1360,10 +1488,46 @@ export class UserApi extends BaseAPI {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public deleteUserById(userId: string, options?: RawAxiosRequestConfig) {
-        return UserApiFp(this.configuration).deleteUserById(userId, options).then((request) => request(this.axios, this.basePath));
-    }
+    deleteUserById: async (
+      userId: string,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'userId' is not null or undefined
+      assertParamExists('deleteUserById', 'userId', userId);
+      const localVarPath = `/users/{user_id}`.replace(
+        `{${'user_id'}}`,
+        encodeURIComponent(String(userId))
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
+      const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
     /**
      * get one user
      * @summary get one user
@@ -1371,10 +1535,46 @@ export class UserApi extends BaseAPI {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public getOneUserById(userId: string, options?: RawAxiosRequestConfig) {
-        return UserApiFp(this.configuration).getOneUserById(userId, options).then((request) => request(this.axios, this.basePath));
-    }
+    getOneUserById: async (
+      userId: string,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'userId' is not null or undefined
+      assertParamExists('getOneUserById', 'userId', userId);
+      const localVarPath = `/users/{user_id}`.replace(
+        `{${'user_id'}}`,
+        encodeURIComponent(String(userId))
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
     /**
      * get users
      * @summary get users
@@ -1389,257 +1589,495 @@ export class UserApi extends BaseAPI {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public getUsers(offset?: string, limit?: string, userId?: string, email?: string, displayName?: string, organization?: string, status?: UsersUserStatus, groupId?: string, options?: RawAxiosRequestConfig) {
-        return UserApiFp(this.configuration).getUsers(offset, limit, userId, email, displayName, organization, status, groupId, options).then((request) => request(this.axios, this.basePath));
-    }
+    getUsers: async (
+      offset?: string,
+      limit?: string,
+      userId?: string,
+      email?: string,
+      displayName?: string,
+      organization?: string,
+      status?: UsersUserStatus,
+      groupId?: string,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      const localVarPath = `/users`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      if (offset !== undefined) {
+        localVarQueryParameter['offset'] = offset;
+      }
+
+      if (limit !== undefined) {
+        localVarQueryParameter['limit'] = limit;
+      }
+
+      if (userId !== undefined) {
+        localVarQueryParameter['user_id'] = userId;
+      }
+
+      if (email !== undefined) {
+        localVarQueryParameter['email'] = email;
+      }
+
+      if (displayName !== undefined) {
+        localVarQueryParameter['display_name'] = displayName;
+      }
+
+      if (organization !== undefined) {
+        localVarQueryParameter['organization'] = organization;
+      }
+
+      if (status !== undefined) {
+        localVarQueryParameter['status'] = status;
+      }
+
+      if (groupId !== undefined) {
+        localVarQueryParameter['group_id'] = groupId;
+      }
+
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
     /**
      * update user status
      * @summary update user status
      * @param {string} userId User ID
-     * @param {UsersUpdateUserRequest} usersUpdateUserRequest 
+     * @param {UsersUpdateUserRequest} usersUpdateUserRequest
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public updatetUserStatusById(userId: string, usersUpdateUserRequest: UsersUpdateUserRequest, options?: RawAxiosRequestConfig) {
-        return UserApiFp(this.configuration).updatetUserStatusById(userId, usersUpdateUserRequest, options).then((request) => request(this.axios, this.basePath));
-    }
+    updatetUserStatusById: async (
+      userId: string,
+      usersUpdateUserRequest: UsersUpdateUserRequest,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'userId' is not null or undefined
+      assertParamExists('updatetUserStatusById', 'userId', userId);
+      // verify required parameter 'usersUpdateUserRequest' is not null or undefined
+      assertParamExists('updatetUserStatusById', 'usersUpdateUserRequest', usersUpdateUserRequest);
+      const localVarPath = `/users/{user_id}`.replace(
+        `{${'user_id'}}`,
+        encodeURIComponent(String(userId))
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+
+      const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter['Content-Type'] = 'application/json';
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        usersUpdateUserRequest,
+        localVarRequestOptions,
+        configuration
+      );
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+  };
+};
+
+/**
+ * UserApi - functional programming interface
+ */
+export const UserApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator = UserApiAxiosParamCreator(configuration);
+  return {
+    /**
+     * delete user with designated id
+     * @summary delete user
+     * @param {string} userId User ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async deleteUserById(
+      userId: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUserById(userId, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['UserApi.deleteUserById']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * get one user
+     * @summary get one user
+     * @param {string} userId User ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getOneUserById(
+      userId: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<UsersGetOneUserResponse>
+    > {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.getOneUserById(userId, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['UserApi.getOneUserById']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * get users
+     * @summary get users
+     * @param {string} [offset] offset information
+     * @param {string} [limit] Limit information
+     * @param {string} [userId] query user id
+     * @param {string} [email] query email information
+     * @param {string} [displayName] query display name information
+     * @param {string} [organization] query organization information
+     * @param {UsersUserStatus} [status] query user status
+     * @param {string} [groupId] query group ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getUsers(
+      offset?: string,
+      limit?: string,
+      userId?: string,
+      email?: string,
+      displayName?: string,
+      organization?: string,
+      status?: UsersUserStatus,
+      groupId?: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<UsersGetUsersResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.getUsers(
+        offset,
+        limit,
+        userId,
+        email,
+        displayName,
+        organization,
+        status,
+        groupId,
+        options
+      );
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['UserApi.getUsers']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * update user status
+     * @summary update user status
+     * @param {string} userId User ID
+     * @param {UsersUpdateUserRequest} usersUpdateUserRequest
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async updatetUserStatusById(
+      userId: string,
+      usersUpdateUserRequest: UsersUpdateUserRequest,
+      options?: RawAxiosRequestConfig
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<UsersGetOneUserResponse>
+    > {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.updatetUserStatusById(
+        userId,
+        usersUpdateUserRequest,
+        options
+      );
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['UserApi.updatetUserStatusById']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+  };
+};
+
+/**
+ * UserApi - factory interface
+ */
+export const UserApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance
+) {
+  const localVarFp = UserApiFp(configuration);
+  return {
+    /**
+     * delete user with designated id
+     * @summary delete user
+     * @param {string} userId User ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deleteUserById(userId: string, options?: RawAxiosRequestConfig): AxiosPromise<void> {
+      return localVarFp.deleteUserById(userId, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * get one user
+     * @summary get one user
+     * @param {string} userId User ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getOneUserById(
+      userId: string,
+      options?: RawAxiosRequestConfig
+    ): AxiosPromise<UsersGetOneUserResponse> {
+      return localVarFp.getOneUserById(userId, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * get users
+     * @summary get users
+     * @param {string} [offset] offset information
+     * @param {string} [limit] Limit information
+     * @param {string} [userId] query user id
+     * @param {string} [email] query email information
+     * @param {string} [displayName] query display name information
+     * @param {string} [organization] query organization information
+     * @param {UsersUserStatus} [status] query user status
+     * @param {string} [groupId] query group ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getUsers(
+      offset?: string,
+      limit?: string,
+      userId?: string,
+      email?: string,
+      displayName?: string,
+      organization?: string,
+      status?: UsersUserStatus,
+      groupId?: string,
+      options?: RawAxiosRequestConfig
+    ): AxiosPromise<UsersGetUsersResponse> {
+      return localVarFp
+        .getUsers(offset, limit, userId, email, displayName, organization, status, groupId, options)
+        .then((request) => request(axios, basePath));
+    },
+    /**
+     * update user status
+     * @summary update user status
+     * @param {string} userId User ID
+     * @param {UsersUpdateUserRequest} usersUpdateUserRequest
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    updatetUserStatusById(
+      userId: string,
+      usersUpdateUserRequest: UsersUpdateUserRequest,
+      options?: RawAxiosRequestConfig
+    ): AxiosPromise<UsersGetOneUserResponse> {
+      return localVarFp
+        .updatetUserStatusById(userId, usersUpdateUserRequest, options)
+        .then((request) => request(axios, basePath));
+    },
+  };
+};
+
+/**
+ * UserApi - object-oriented interface
+ */
+export class UserApi extends BaseAPI {
+  /**
+   * delete user with designated id
+   * @summary delete user
+   * @param {string} userId User ID
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public deleteUserById(userId: string, options?: RawAxiosRequestConfig) {
+    return UserApiFp(this.configuration)
+      .deleteUserById(userId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * get one user
+   * @summary get one user
+   * @param {string} userId User ID
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public getOneUserById(userId: string, options?: RawAxiosRequestConfig) {
+    return UserApiFp(this.configuration)
+      .getOneUserById(userId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * get users
+   * @summary get users
+   * @param {string} [offset] offset information
+   * @param {string} [limit] Limit information
+   * @param {string} [userId] query user id
+   * @param {string} [email] query email information
+   * @param {string} [displayName] query display name information
+   * @param {string} [organization] query organization information
+   * @param {UsersUserStatus} [status] query user status
+   * @param {string} [groupId] query group ID
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public getUsers(
+    offset?: string,
+    limit?: string,
+    userId?: string,
+    email?: string,
+    displayName?: string,
+    organization?: string,
+    status?: UsersUserStatus,
+    groupId?: string,
+    options?: RawAxiosRequestConfig
+  ) {
+    return UserApiFp(this.configuration)
+      .getUsers(offset, limit, userId, email, displayName, organization, status, groupId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * update user status
+   * @summary update user status
+   * @param {string} userId User ID
+   * @param {UsersUpdateUserRequest} usersUpdateUserRequest
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public updatetUserStatusById(
+    userId: string,
+    usersUpdateUserRequest: UsersUpdateUserRequest,
+    options?: RawAxiosRequestConfig
+  ) {
+    return UserApiFp(this.configuration)
+      .updatetUserStatusById(userId, usersUpdateUserRequest, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 }
-
-
 
 /**
  * WhitelistUsersApi - axios parameter creator
  */
 export const WhitelistUsersApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * delete a user from the whitelist
-         * @summary delete a user from the whitelist
-         * @param {WhitelistUsersWhitelistUsersDeleteRequest} whitelistUsersWhitelistUsersDeleteRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteWhitelistUser: async (whitelistUsersWhitelistUsersDeleteRequest: WhitelistUsersWhitelistUsersDeleteRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'whitelistUsersWhitelistUsersDeleteRequest' is not null or undefined
-            assertParamExists('deleteWhitelistUser', 'whitelistUsersWhitelistUsersDeleteRequest', whitelistUsersWhitelistUsersDeleteRequest)
-            const localVarPath = `/whitelist_users`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(whitelistUsersWhitelistUsersDeleteRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * List whitelist users
-         * @summary List whitelist users
-         * @param {string} [offset] offset information
-         * @param {string} [limit] Limit information
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        listWhitelistUsers: async (offset?: string, limit?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/whitelist_users`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            if (offset !== undefined) {
-                localVarQueryParameter['offset'] = offset;
-            }
-
-            if (limit !== undefined) {
-                localVarQueryParameter['limit'] = limit;
-            }
-
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * register a user to the whitelist
-         * @summary register a user to the whitelist
-         * @param {WhitelistUsersRegisterWhitelistUsersRequest} [whitelistUsersRegisterWhitelistUsersRequest] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        registerWhitelistUser: async (whitelistUsersRegisterWhitelistUsersRequest?: WhitelistUsersRegisterWhitelistUsersRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/whitelist_users`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-            localVarHeaderParameter['Accept'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(whitelistUsersRegisterWhitelistUsersRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
-};
-
-/**
- * WhitelistUsersApi - functional programming interface
- */
-export const WhitelistUsersApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = WhitelistUsersApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * delete a user from the whitelist
-         * @summary delete a user from the whitelist
-         * @param {WhitelistUsersWhitelistUsersDeleteRequest} whitelistUsersWhitelistUsersDeleteRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async deleteWhitelistUser(whitelistUsersWhitelistUsersDeleteRequest: WhitelistUsersWhitelistUsersDeleteRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteWhitelistUser(whitelistUsersWhitelistUsersDeleteRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['WhitelistUsersApi.deleteWhitelistUser']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * List whitelist users
-         * @summary List whitelist users
-         * @param {string} [offset] offset information
-         * @param {string} [limit] Limit information
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async listWhitelistUsers(offset?: string, limit?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<WhitelistUsersListWhitelistUsersResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.listWhitelistUsers(offset, limit, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['WhitelistUsersApi.listWhitelistUsers']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * register a user to the whitelist
-         * @summary register a user to the whitelist
-         * @param {WhitelistUsersRegisterWhitelistUsersRequest} [whitelistUsersRegisterWhitelistUsersRequest] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async registerWhitelistUser(whitelistUsersRegisterWhitelistUsersRequest?: WhitelistUsersRegisterWhitelistUsersRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SuccessSuccessResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.registerWhitelistUser(whitelistUsersRegisterWhitelistUsersRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['WhitelistUsersApi.registerWhitelistUser']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
-};
-
-/**
- * WhitelistUsersApi - factory interface
- */
-export const WhitelistUsersApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = WhitelistUsersApiFp(configuration)
-    return {
-        /**
-         * delete a user from the whitelist
-         * @summary delete a user from the whitelist
-         * @param {WhitelistUsersWhitelistUsersDeleteRequest} whitelistUsersWhitelistUsersDeleteRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteWhitelistUser(whitelistUsersWhitelistUsersDeleteRequest: WhitelistUsersWhitelistUsersDeleteRequest, options?: RawAxiosRequestConfig): AxiosPromise<void> {
-            return localVarFp.deleteWhitelistUser(whitelistUsersWhitelistUsersDeleteRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * List whitelist users
-         * @summary List whitelist users
-         * @param {string} [offset] offset information
-         * @param {string} [limit] Limit information
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        listWhitelistUsers(offset?: string, limit?: string, options?: RawAxiosRequestConfig): AxiosPromise<WhitelistUsersListWhitelistUsersResponse> {
-            return localVarFp.listWhitelistUsers(offset, limit, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * register a user to the whitelist
-         * @summary register a user to the whitelist
-         * @param {WhitelistUsersRegisterWhitelistUsersRequest} [whitelistUsersRegisterWhitelistUsersRequest] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        registerWhitelistUser(whitelistUsersRegisterWhitelistUsersRequest?: WhitelistUsersRegisterWhitelistUsersRequest, options?: RawAxiosRequestConfig): AxiosPromise<SuccessSuccessResponse> {
-            return localVarFp.registerWhitelistUser(whitelistUsersRegisterWhitelistUsersRequest, options).then((request) => request(axios, basePath));
-        },
-    };
-};
-
-/**
- * WhitelistUsersApi - object-oriented interface
- */
-export class WhitelistUsersApi extends BaseAPI {
+  return {
     /**
      * delete a user from the whitelist
      * @summary delete a user from the whitelist
-     * @param {WhitelistUsersWhitelistUsersDeleteRequest} whitelistUsersWhitelistUsersDeleteRequest 
+     * @param {WhitelistUsersWhitelistUsersDeleteRequest} whitelistUsersWhitelistUsersDeleteRequest
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public deleteWhitelistUser(whitelistUsersWhitelistUsersDeleteRequest: WhitelistUsersWhitelistUsersDeleteRequest, options?: RawAxiosRequestConfig) {
-        return WhitelistUsersApiFp(this.configuration).deleteWhitelistUser(whitelistUsersWhitelistUsersDeleteRequest, options).then((request) => request(this.axios, this.basePath));
-    }
+    deleteWhitelistUser: async (
+      whitelistUsersWhitelistUsersDeleteRequest: WhitelistUsersWhitelistUsersDeleteRequest,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'whitelistUsersWhitelistUsersDeleteRequest' is not null or undefined
+      assertParamExists(
+        'deleteWhitelistUser',
+        'whitelistUsersWhitelistUsersDeleteRequest',
+        whitelistUsersWhitelistUsersDeleteRequest
+      );
+      const localVarPath = `/whitelist_users`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
+      const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter['Content-Type'] = 'application/json';
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        whitelistUsersWhitelistUsersDeleteRequest,
+        localVarRequestOptions,
+        configuration
+      );
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
     /**
      * List whitelist users
      * @summary List whitelist users
@@ -1648,21 +2086,307 @@ export class WhitelistUsersApi extends BaseAPI {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public listWhitelistUsers(offset?: string, limit?: string, options?: RawAxiosRequestConfig) {
-        return WhitelistUsersApiFp(this.configuration).listWhitelistUsers(offset, limit, options).then((request) => request(this.axios, this.basePath));
-    }
+    listWhitelistUsers: async (
+      offset?: string,
+      limit?: string,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      const localVarPath = `/whitelist_users`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      if (offset !== undefined) {
+        localVarQueryParameter['offset'] = offset;
+      }
+
+      if (limit !== undefined) {
+        localVarQueryParameter['limit'] = limit;
+      }
+
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
     /**
      * register a user to the whitelist
      * @summary register a user to the whitelist
-     * @param {WhitelistUsersRegisterWhitelistUsersRequest} [whitelistUsersRegisterWhitelistUsersRequest] 
+     * @param {WhitelistUsersRegisterWhitelistUsersRequest} [whitelistUsersRegisterWhitelistUsersRequest]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    public registerWhitelistUser(whitelistUsersRegisterWhitelistUsersRequest?: WhitelistUsersRegisterWhitelistUsersRequest, options?: RawAxiosRequestConfig) {
-        return WhitelistUsersApiFp(this.configuration).registerWhitelistUser(whitelistUsersRegisterWhitelistUsersRequest, options).then((request) => request(this.axios, this.basePath));
-    }
+    registerWhitelistUser: async (
+      whitelistUsersRegisterWhitelistUsersRequest?: WhitelistUsersRegisterWhitelistUsersRequest,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      const localVarPath = `/whitelist_users`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication BearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter['Content-Type'] = 'application/json';
+      localVarHeaderParameter['Accept'] = 'application/json';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        whitelistUsersRegisterWhitelistUsersRequest,
+        localVarRequestOptions,
+        configuration
+      );
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+  };
+};
+
+/**
+ * WhitelistUsersApi - functional programming interface
+ */
+export const WhitelistUsersApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator = WhitelistUsersApiAxiosParamCreator(configuration);
+  return {
+    /**
+     * delete a user from the whitelist
+     * @summary delete a user from the whitelist
+     * @param {WhitelistUsersWhitelistUsersDeleteRequest} whitelistUsersWhitelistUsersDeleteRequest
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async deleteWhitelistUser(
+      whitelistUsersWhitelistUsersDeleteRequest: WhitelistUsersWhitelistUsersDeleteRequest,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.deleteWhitelistUser(
+        whitelistUsersWhitelistUsersDeleteRequest,
+        options
+      );
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['WhitelistUsersApi.deleteWhitelistUser']?.[localVarOperationServerIndex]
+          ?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * List whitelist users
+     * @summary List whitelist users
+     * @param {string} [offset] offset information
+     * @param {string} [limit] Limit information
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async listWhitelistUsers(
+      offset?: string,
+      limit?: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<
+      (
+        axios?: AxiosInstance,
+        basePath?: string
+      ) => AxiosPromise<WhitelistUsersListWhitelistUsersResponse>
+    > {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.listWhitelistUsers(
+        offset,
+        limit,
+        options
+      );
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['WhitelistUsersApi.listWhitelistUsers']?.[localVarOperationServerIndex]
+          ?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * register a user to the whitelist
+     * @summary register a user to the whitelist
+     * @param {WhitelistUsersRegisterWhitelistUsersRequest} [whitelistUsersRegisterWhitelistUsersRequest]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async registerWhitelistUser(
+      whitelistUsersRegisterWhitelistUsersRequest?: WhitelistUsersRegisterWhitelistUsersRequest,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SuccessSuccessResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.registerWhitelistUser(
+        whitelistUsersRegisterWhitelistUsersRequest,
+        options
+      );
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['WhitelistUsersApi.registerWhitelistUser']?.[
+          localVarOperationServerIndex
+        ]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+  };
+};
+
+/**
+ * WhitelistUsersApi - factory interface
+ */
+export const WhitelistUsersApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance
+) {
+  const localVarFp = WhitelistUsersApiFp(configuration);
+  return {
+    /**
+     * delete a user from the whitelist
+     * @summary delete a user from the whitelist
+     * @param {WhitelistUsersWhitelistUsersDeleteRequest} whitelistUsersWhitelistUsersDeleteRequest
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deleteWhitelistUser(
+      whitelistUsersWhitelistUsersDeleteRequest: WhitelistUsersWhitelistUsersDeleteRequest,
+      options?: RawAxiosRequestConfig
+    ): AxiosPromise<void> {
+      return localVarFp
+        .deleteWhitelistUser(whitelistUsersWhitelistUsersDeleteRequest, options)
+        .then((request) => request(axios, basePath));
+    },
+    /**
+     * List whitelist users
+     * @summary List whitelist users
+     * @param {string} [offset] offset information
+     * @param {string} [limit] Limit information
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    listWhitelistUsers(
+      offset?: string,
+      limit?: string,
+      options?: RawAxiosRequestConfig
+    ): AxiosPromise<WhitelistUsersListWhitelistUsersResponse> {
+      return localVarFp
+        .listWhitelistUsers(offset, limit, options)
+        .then((request) => request(axios, basePath));
+    },
+    /**
+     * register a user to the whitelist
+     * @summary register a user to the whitelist
+     * @param {WhitelistUsersRegisterWhitelistUsersRequest} [whitelistUsersRegisterWhitelistUsersRequest]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    registerWhitelistUser(
+      whitelistUsersRegisterWhitelistUsersRequest?: WhitelistUsersRegisterWhitelistUsersRequest,
+      options?: RawAxiosRequestConfig
+    ): AxiosPromise<SuccessSuccessResponse> {
+      return localVarFp
+        .registerWhitelistUser(whitelistUsersRegisterWhitelistUsersRequest, options)
+        .then((request) => request(axios, basePath));
+    },
+  };
+};
+
+/**
+ * WhitelistUsersApi - object-oriented interface
+ */
+export class WhitelistUsersApi extends BaseAPI {
+  /**
+   * delete a user from the whitelist
+   * @summary delete a user from the whitelist
+   * @param {WhitelistUsersWhitelistUsersDeleteRequest} whitelistUsersWhitelistUsersDeleteRequest
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public deleteWhitelistUser(
+    whitelistUsersWhitelistUsersDeleteRequest: WhitelistUsersWhitelistUsersDeleteRequest,
+    options?: RawAxiosRequestConfig
+  ) {
+    return WhitelistUsersApiFp(this.configuration)
+      .deleteWhitelistUser(whitelistUsersWhitelistUsersDeleteRequest, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * List whitelist users
+   * @summary List whitelist users
+   * @param {string} [offset] offset information
+   * @param {string} [limit] Limit information
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public listWhitelistUsers(offset?: string, limit?: string, options?: RawAxiosRequestConfig) {
+    return WhitelistUsersApiFp(this.configuration)
+      .listWhitelistUsers(offset, limit, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * register a user to the whitelist
+   * @summary register a user to the whitelist
+   * @param {WhitelistUsersRegisterWhitelistUsersRequest} [whitelistUsersRegisterWhitelistUsersRequest]
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   */
+  public registerWhitelistUser(
+    whitelistUsersRegisterWhitelistUsersRequest?: WhitelistUsersRegisterWhitelistUsersRequest,
+    options?: RawAxiosRequestConfig
+  ) {
+    return WhitelistUsersApiFp(this.configuration)
+      .registerWhitelistUser(whitelistUsersRegisterWhitelistUsersRequest, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 }
-
-
-

--- a/src/api/generated/docs/DevicesApi.md
+++ b/src/api/generated/docs/DevicesApi.md
@@ -1,16 +1,18 @@
 # DevicesApi
 
-All URIs are relative to *http://localhost:8080*
+All URIs are relative to _http://localhost:8080_
 
-|Method | HTTP request | Description|
-|------------- | ------------- | -------------|
-|[**deleteDevice**](#deletedevice) | **DELETE** /devices/{device_id} | Delete a device|
-|[**getDevice**](#getdevice) | **GET** /devices/{device_id} | Get specified device details|
-|[**listDevices**](#listdevices) | **GET** /devices | List available devices|
-|[**registerDevice**](#registerdevice) | **POST** /devices | Register a new device|
-|[**updateDeviceData**](#updatedevicedata) | **PATCH** /devices/{device_id} | Update data of selected device|
+| Method                                                | HTTP request                                    | Description                                    |
+| ----------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------- |
+| [**deleteDevice**](#deletedevice)                     | **DELETE** /devices/{device_id}                 | Delete a device                                |
+| [**getDevice**](#getdevice)                           | **GET** /devices/{device_id}                    | Get specified device details                   |
+| [**getDeviceInfoUploadUrl**](#getdeviceinfouploadurl) | **GET** /devices/{device_id}/device_info/upload | Generate a presigned URL to upload device_info |
+| [**listDevices**](#listdevices)                       | **GET** /devices                                | List available devices                         |
+| [**registerDevice**](#registerdevice)                 | **POST** /devices                               | Register a new device                          |
+| [**updateDeviceData**](#updatedevicedata)             | **PATCH** /devices/{device_id}                  | Update data of selected device                 |
 
 # **deleteDevice**
+
 > SuccessSuccessResponse deleteDevice()
 
 Delete a device from the system.
@@ -18,27 +20,21 @@ Delete a device from the system.
 ### Example
 
 ```typescript
-import {
-    DevicesApi,
-    Configuration
-} from './api';
+import { DevicesApi, Configuration } from './api';
 
 const configuration = new Configuration();
 const apiInstance = new DevicesApi(configuration);
 
 let deviceId: string; //Device ID (default to undefined)
 
-const { status, data } = await apiInstance.deleteDevice(
-    deviceId
-);
+const { status, data } = await apiInstance.deleteDevice(deviceId);
 ```
 
 ### Parameters
 
-|Name | Type | Description  | Notes|
-|------------- | ------------- | ------------- | -------------|
-| **deviceId** | [**string**] | Device ID | defaults to undefined|
-
+| Name         | Type         | Description | Notes                 |
+| ------------ | ------------ | ----------- | --------------------- |
+| **deviceId** | [**string**] | Device ID   | defaults to undefined |
 
 ### Return type
 
@@ -50,23 +46,24 @@ const { status, data } = await apiInstance.deleteDevice(
 
 ### HTTP request headers
 
- - **Content-Type**: Not defined
- - **Accept**: application/json
-
+- **Content-Type**: Not defined
+- **Accept**: application/json
 
 ### HTTP response details
-| Status code | Description | Response headers |
-|-------------|-------------|------------------|
-|**204** | Device deleted |  -  |
-|**400** | Bad Request |  -  |
-|**401** | Unauthorized |  -  |
-|**403** | Not authorized |  -  |
-|**404** | Not Found |  -  |
-|**500** | Internal Server Error |  -  |
+
+| Status code | Description           | Response headers |
+| ----------- | --------------------- | ---------------- |
+| **204**     | Device deleted        | -                |
+| **400**     | Bad Request           | -                |
+| **401**     | Unauthorized          | -                |
+| **403**     | Not authorized        | -                |
+| **404**     | Not Found             | -                |
+| **500**     | Internal Server Error | -                |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **getDevice**
+
 > DevicesDeviceInfo getDevice()
 
 get device
@@ -74,27 +71,21 @@ get device
 ### Example
 
 ```typescript
-import {
-    DevicesApi,
-    Configuration
-} from './api';
+import { DevicesApi, Configuration } from './api';
 
 const configuration = new Configuration();
 const apiInstance = new DevicesApi(configuration);
 
 let deviceId: string; //Device identifier (default to undefined)
 
-const { status, data } = await apiInstance.getDevice(
-    deviceId
-);
+const { status, data } = await apiInstance.getDevice(deviceId);
 ```
 
 ### Parameters
 
-|Name | Type | Description  | Notes|
-|------------- | ------------- | ------------- | -------------|
-| **deviceId** | [**string**] | Device identifier | defaults to undefined|
-
+| Name         | Type         | Description       | Notes                 |
+| ------------ | ------------ | ----------------- | --------------------- |
+| **deviceId** | [**string**] | Device identifier | defaults to undefined |
 
 ### Return type
 
@@ -106,20 +97,71 @@ const { status, data } = await apiInstance.getDevice(
 
 ### HTTP request headers
 
- - **Content-Type**: Not defined
- - **Accept**: application/json
-
+- **Content-Type**: Not defined
+- **Accept**: application/json
 
 ### HTTP response details
-| Status code | Description | Response headers |
-|-------------|-------------|------------------|
-|**200** | device response |  -  |
-|**404** | Device with device_id not found |  -  |
-|**500** | Internal Server Error |  -  |
+
+| Status code | Description                     | Response headers |
+| ----------- | ------------------------------- | ---------------- |
+| **200**     | device response                 | -                |
+| **404**     | Device with device_id not found | -                |
+| **500**     | Internal Server Error           | -                |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **getDeviceInfoUploadUrl**
+
+> DevicesDeviceInfoUploadResponse getDeviceInfoUploadUrl()
+
+Generate a presigned URL to upload device_info for the selected device.
+
+### Example
+
+```typescript
+import { DevicesApi, Configuration } from './api';
+
+const configuration = new Configuration();
+const apiInstance = new DevicesApi(configuration);
+
+let deviceId: string; //Device ID (default to undefined)
+
+const { status, data } = await apiInstance.getDeviceInfoUploadUrl(deviceId);
+```
+
+### Parameters
+
+| Name         | Type         | Description | Notes                 |
+| ------------ | ------------ | ----------- | --------------------- |
+| **deviceId** | [**string**] | Device ID   | defaults to undefined |
+
+### Return type
+
+**DevicesDeviceInfoUploadResponse**
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
+
+### HTTP response details
+
+| Status code | Description                      | Response headers |
+| ----------- | -------------------------------- | ---------------- |
+| **200**     | Device_info upload URL generated | -                |
+| **401**     | Unauthorized                     | -                |
+| **403**     | Not authorized                   | -                |
+| **404**     | Not Found                        | -                |
+| **500**     | Internal Server Error            | -                |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **listDevices**
+
 > Array<DevicesDeviceInfo> listDevices()
 
 List available devices
@@ -127,10 +169,7 @@ List available devices
 ### Example
 
 ```typescript
-import {
-    DevicesApi,
-    Configuration
-} from './api';
+import { DevicesApi, Configuration } from './api';
 
 const configuration = new Configuration();
 const apiInstance = new DevicesApi(configuration);
@@ -139,8 +178,8 @@ const { status, data } = await apiInstance.listDevices();
 ```
 
 ### Parameters
-This endpoint does not have any parameters.
 
+This endpoint does not have any parameters.
 
 ### Return type
 
@@ -152,21 +191,22 @@ This endpoint does not have any parameters.
 
 ### HTTP request headers
 
- - **Content-Type**: Not defined
- - **Accept**: application/json
-
+- **Content-Type**: Not defined
+- **Accept**: application/json
 
 ### HTTP response details
-| Status code | Description | Response headers |
-|-------------|-------------|------------------|
-|**200** | Returns a list of available devices |  -  |
-|**401** | Unauthorized |  -  |
-|**403** | Not authorized |  -  |
-|**500** | Internal Server Error |  -  |
+
+| Status code | Description                         | Response headers |
+| ----------- | ----------------------------------- | ---------------- |
+| **200**     | Returns a list of available devices | -                |
+| **401**     | Unauthorized                        | -                |
+| **403**     | Not authorized                      | -                |
+| **500**     | Internal Server Error               | -                |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **registerDevice**
+
 > SuccessSuccessResponse registerDevice()
 
 Register a new device to the system.
@@ -174,28 +214,21 @@ Register a new device to the system.
 ### Example
 
 ```typescript
-import {
-    DevicesApi,
-    Configuration,
-    DevicesDeviceBase
-} from './api';
+import { DevicesApi, Configuration, DevicesDeviceBase } from './api';
 
 const configuration = new Configuration();
 const apiInstance = new DevicesApi(configuration);
 
 let devicesDeviceBase: DevicesDeviceBase; //Device data (optional)
 
-const { status, data } = await apiInstance.registerDevice(
-    devicesDeviceBase
-);
+const { status, data } = await apiInstance.registerDevice(devicesDeviceBase);
 ```
 
 ### Parameters
 
-|Name | Type | Description  | Notes|
-|------------- | ------------- | ------------- | -------------|
-| **devicesDeviceBase** | **DevicesDeviceBase**| Device data | |
-
+| Name                  | Type                  | Description | Notes |
+| --------------------- | --------------------- | ----------- | ----- |
+| **devicesDeviceBase** | **DevicesDeviceBase** | Device data |       |
 
 ### Return type
 
@@ -207,22 +240,23 @@ const { status, data } = await apiInstance.registerDevice(
 
 ### HTTP request headers
 
- - **Content-Type**: application/json
- - **Accept**: application/json
-
+- **Content-Type**: application/json
+- **Accept**: application/json
 
 ### HTTP response details
-| Status code | Description | Response headers |
-|-------------|-------------|------------------|
-|**200** | Device registered |  -  |
-|**400** | Bad Request |  -  |
-|**401** | Unauthorized |  -  |
-|**403** | Not authorized |  -  |
-|**500** | Internal Server Error |  -  |
+
+| Status code | Description           | Response headers |
+| ----------- | --------------------- | ---------------- |
+| **200**     | Device registered     | -                |
+| **400**     | Bad Request           | -                |
+| **401**     | Unauthorized          | -                |
+| **403**     | Not authorized        | -                |
+| **500**     | Internal Server Error | -                |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updateDeviceData**
+
 > SuccessSuccessResponse updateDeviceData()
 
 Update the properties of selected device.
@@ -230,11 +264,7 @@ Update the properties of selected device.
 ### Example
 
 ```typescript
-import {
-    DevicesApi,
-    Configuration,
-    DevicesDeviceBase
-} from './api';
+import { DevicesApi, Configuration, DevicesDeviceBase } from './api';
 
 const configuration = new Configuration();
 const apiInstance = new DevicesApi(configuration);
@@ -242,19 +272,15 @@ const apiInstance = new DevicesApi(configuration);
 let deviceId: string; //Device ID (default to undefined)
 let devicesDeviceBase: DevicesDeviceBase; //New calibration data (optional)
 
-const { status, data } = await apiInstance.updateDeviceData(
-    deviceId,
-    devicesDeviceBase
-);
+const { status, data } = await apiInstance.updateDeviceData(deviceId, devicesDeviceBase);
 ```
 
 ### Parameters
 
-|Name | Type | Description  | Notes|
-|------------- | ------------- | ------------- | -------------|
-| **devicesDeviceBase** | **DevicesDeviceBase**| New calibration data | |
-| **deviceId** | [**string**] | Device ID | defaults to undefined|
-
+| Name                  | Type                  | Description          | Notes                 |
+| --------------------- | --------------------- | -------------------- | --------------------- |
+| **devicesDeviceBase** | **DevicesDeviceBase** | New calibration data |                       |
+| **deviceId**          | [**string**]          | Device ID            | defaults to undefined |
 
 ### Return type
 
@@ -266,19 +292,18 @@ const { status, data } = await apiInstance.updateDeviceData(
 
 ### HTTP request headers
 
- - **Content-Type**: application/json
- - **Accept**: application/json
-
+- **Content-Type**: application/json
+- **Accept**: application/json
 
 ### HTTP response details
-| Status code | Description | Response headers |
-|-------------|-------------|------------------|
-|**200** | Device\&#39;s data updated |  -  |
-|**400** | Bad Request |  -  |
-|**401** | Unauthorized |  -  |
-|**403** | Not authorized |  -  |
-|**404** | Not Found |  -  |
-|**500** | Internal Server Error |  -  |
+
+| Status code | Description                | Response headers |
+| ----------- | -------------------------- | ---------------- |
+| **200**     | Device\&#39;s data updated | -                |
+| **400**     | Bad Request                | -                |
+| **401**     | Unauthorized               | -                |
+| **403**     | Not authorized             | -                |
+| **404**     | Not Found                  | -                |
+| **500**     | Internal Server Error      | -                |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-

--- a/src/api/generated/docs/DevicesDeviceInfoUploadPresignedURL.md
+++ b/src/api/generated/docs/DevicesDeviceInfoUploadPresignedURL.md
@@ -1,0 +1,23 @@
+# DevicesDeviceInfoUploadPresignedURL
+
+Presigned URL for uploading device_info.zip to OQTOPUS cloud.
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**url** | **string** |  | [default to undefined]
+**fields** | **{ [key: string]: any; }** |  | [default to undefined]
+
+## Example
+
+```typescript
+import { DevicesDeviceInfoUploadPresignedURL } from './api';
+
+const instance: DevicesDeviceInfoUploadPresignedURL = {
+    url,
+    fields,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/src/api/generated/docs/DevicesDeviceInfoUploadResponse.md
+++ b/src/api/generated/docs/DevicesDeviceInfoUploadResponse.md
@@ -1,0 +1,20 @@
+# DevicesDeviceInfoUploadResponse
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**presigned_url** | [**DevicesDeviceInfoUploadPresignedURL**](DevicesDeviceInfoUploadPresignedURL.md) |  | [default to undefined]
+
+## Example
+
+```typescript
+import { DevicesDeviceInfoUploadResponse } from './api';
+
+const instance: DevicesDeviceInfoUploadResponse = {
+    presigned_url,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/src/api/generated/openapi.yaml
+++ b/src/api/generated/openapi.yaml
@@ -416,7 +416,7 @@ paths:
           required: true
           schema:
             type: string
-          example: Kawasaki
+          example: qulacs
       responses:
         '200':
           description: device response
@@ -451,7 +451,7 @@ paths:
           required: true
           schema:
             type: string
-            example: Kawasaki
+            example: qulacs
       requestBody:
         description: New calibration data
         content:
@@ -510,7 +510,7 @@ paths:
           required: true
           schema:
             type: string
-            example: Kawasaki
+            example: qulacs
       responses:
         '204':
           description: Device deleted
@@ -546,6 +546,52 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error.InternalServerError'
+              example:
+                message: Internal server error
+  /devices/{device_id}/device_info/upload:
+    get:
+      tags:
+        - devices
+      summary: Generate a presigned URL to upload device_info
+      description: Generate a presigned URL to upload device_info for the selected device.
+      operationId: get_device_info_upload_url
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: device_id
+          description: Device ID
+          required: true
+          schema:
+            type: string
+            example: qulacs
+      responses:
+        '200':
+          description: Device_info upload URL generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/devices.DeviceInfoUploadResponse'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Not authorized
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error.NotFoundError'
+              example:
+                message: Device not found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error.InternalServerError'
+              example:
+                message: Internal server error
   /announcements:
     get:
       tags:
@@ -1118,7 +1164,7 @@ components:
       properties:
         device_info:
           type: string
-          example: '{"device_id": "Kawasaki", "qubits": []}'
+          example: '{"device_id": "qulacs", "qubits": []}'
         device_type:
           type: string
           enum:
@@ -1180,6 +1226,26 @@ components:
         description:
           type: string
           example: Superconducting quantum computer
+    devices.DeviceInfoUploadPresignedURL:
+      type: object
+      description: Presigned URL for uploading device_info.zip to OQTOPUS cloud.
+      properties:
+        url:
+          type: string
+          example: https://oqtopus-cloud.s3.amazonaws.com/
+        fields:
+          type: object
+          additionalProperties: true
+      required:
+        - url
+        - fields
+    devices.DeviceInfoUploadResponse:
+      type: object
+      properties:
+        presigned_url:
+          $ref: '#/components/schemas/devices.DeviceInfoUploadPresignedURL'
+      required:
+        - presigned_url
     announcements.GetAnnouncementResponse:
       type: object
       properties:

--- a/src/device/DeviceApi.ts
+++ b/src/device/DeviceApi.ts
@@ -136,20 +136,19 @@ export const useDeviceAPI = () => {
     if (deviceId !== undefined && device.deviceInfo !== undefined) {
       const res = await api.device.getDeviceInfoUploadUrl(deviceId);
       await uploadDeviceInfo(res.data.presigned_url, device.deviceInfo);
-      await api.device.updateDeviceData(deviceId, {
-        device_info: null,
-      } as unknown as SendDbDevice);
     }
   };
 
   const patchDevice = async (deviceId: string, device: DeviceForm) => {
-    const patchData = convertDeviceForm(device);
-    if (device.deviceInfo !== undefined) {
+    const { deviceInfo, ...deviceWithoutInfo } = device;
+    const patchData = convertDeviceForm(deviceWithoutInfo);
+    if (deviceInfo !== undefined) {
       const res = await api.device.getDeviceInfoUploadUrl(deviceId);
-      await uploadDeviceInfo(res.data.presigned_url, device.deviceInfo);
-      patchData.device_info = null as unknown as string;
+      await uploadDeviceInfo(res.data.presigned_url, deviceInfo);
     }
-    await api.device.updateDeviceData(deviceId, patchData);
+    if (Object.keys(patchData).length > 0) {
+      await api.device.updateDeviceData(deviceId, patchData);
+    }
   };
 
   const deleteDevice = async (deviceId: string) => {

--- a/src/device/DeviceApi.ts
+++ b/src/device/DeviceApi.ts
@@ -1,10 +1,79 @@
 import { Device, DeviceForm, SendDbDevice } from '../types/DeviceType';
-import { ApiResponse } from '../types/CommonType';
 import { useContext } from 'react';
-import { DevicesDeviceInfo as ApiDevicesDeviceInfo } from '../api/generated';
+import {
+  DevicesDeviceInfo as ApiDevicesDeviceInfo,
+  DevicesDeviceInfoUploadPresignedURL,
+} from '../api/generated';
 import { userApiContext } from '../backend/Provider';
+import axios from 'axios';
+import JSZip from 'jszip';
 
-const convertDeviceResult = (device: ApiDevicesDeviceInfo): Device => ({
+const isDeviceInfoUrl = (deviceInfo: string | undefined): deviceInfo is string => {
+  if (deviceInfo === undefined || deviceInfo === '') return false;
+  try {
+    const url = new URL(deviceInfo);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+const zipDeviceInfo = async (deviceInfo: string): Promise<Blob> => {
+  const zip = new JSZip();
+  zip.file('device_info.json', deviceInfo);
+  return await zip.generateAsync({ type: 'blob', compression: 'DEFLATE' });
+};
+
+const convertZipBlobToString = async (zipBlob: Blob): Promise<string> => {
+  const zip = await JSZip.loadAsync(zipBlob);
+  const [_, file] = Object.entries(zip.files)[0] ?? [];
+  if (!file) throw new Error('device_info.zip is empty');
+  return await file.async('string');
+};
+
+const retrieveDeviceInfo = async (deviceInfo: string | undefined): Promise<string> => {
+  if (!isDeviceInfoUrl(deviceInfo)) return deviceInfo ?? '';
+
+  const deviceInfoUrl = deviceInfo;
+  const response = await fetch(deviceInfoUrl);
+  const blob = await response.blob();
+  try {
+    return await convertZipBlobToString(blob);
+  } catch {
+    return await blob.text();
+  }
+};
+
+const uploadDeviceInfo = async (
+  presignedUrl: DevicesDeviceInfoUploadPresignedURL,
+  deviceInfo: string
+): Promise<void> => {
+  const { url, fields } = presignedUrl;
+  if (!url || !fields) throw new Error('missing presigned URL data');
+
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    if (value == null) continue;
+    formData.append(key, String(value));
+  }
+  formData.append('file', await zipDeviceInfo(deviceInfo), 'device_info.zip');
+
+  await axios.post(url, formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+};
+
+const extractDeviceId = (device: DeviceForm): string | undefined => {
+  if (!device.deviceInfo) return undefined;
+  try {
+    const deviceInfo = JSON.parse(device.deviceInfo) as { device_id?: unknown };
+    return typeof deviceInfo.device_id === 'string' ? deviceInfo.device_id : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const convertDeviceResult = async (device: ApiDevicesDeviceInfo): Promise<Device> => ({
   id: device.device_id,
   deviceType: device.device_type,
   status: device.status,
@@ -13,7 +82,7 @@ const convertDeviceResult = (device: ApiDevicesDeviceInfo): Device => ({
   nQubits: device.n_qubits ?? 0,
   basisGates: device.basis_gates,
   supportedInstructions: device.supported_instructions,
-  deviceInfo: device.device_info ?? '',
+  deviceInfo: await retrieveDeviceInfo(device.device_info),
   calibratedAt: device.calibrated_at ?? undefined,
   description: device.description,
 });
@@ -53,20 +122,34 @@ export const useDeviceAPI = () => {
 
   const getDevices = async (): Promise<Device[]> => {
     const res = await api.device.listDevices();
-    return res.data.map(convertDeviceResult);
+    return await Promise.all(res.data.map(convertDeviceResult));
   };
 
   const getDevice = async (id: string) => {
     const res = await api.device.getDevice(id);
-    return convertDeviceResult(res.data);
+    return await convertDeviceResult(res.data);
   };
 
   const postDevice = async (device: DeviceForm) => {
     await api.device.registerDevice(convertDeviceForm(device));
+    const deviceId = extractDeviceId(device);
+    if (deviceId !== undefined && device.deviceInfo !== undefined) {
+      const res = await api.device.getDeviceInfoUploadUrl(deviceId);
+      await uploadDeviceInfo(res.data.presigned_url, device.deviceInfo);
+      await api.device.updateDeviceData(deviceId, {
+        device_info: null,
+      } as unknown as SendDbDevice);
+    }
   };
 
   const patchDevice = async (deviceId: string, device: DeviceForm) => {
-    await api.device.updateDeviceData(deviceId, convertDeviceForm(device));
+    const patchData = convertDeviceForm(device);
+    if (device.deviceInfo !== undefined) {
+      const res = await api.device.getDeviceInfoUploadUrl(deviceId);
+      await uploadDeviceInfo(res.data.presigned_url, device.deviceInfo);
+      patchData.device_info = null as unknown as string;
+    }
+    await api.device.updateDeviceData(deviceId, patchData);
   };
 
   const deleteDevice = async (deviceId: string) => {


### PR DESCRIPTION
## Summary

Support storage-backed `device_info` in admin.

- upload `device_info.zip` through presigned URLs
- resolve storage-backed `device_info` URLs on read
- keep device update payloads metadata-only after `device_info` upload

Related issue:
- oqtopus-team/oqtopus-cloud#484

Depends on:
- oqtopus-team/oqtopus-cloud#485